### PR TITLE
feat(us-011,us-013): Add Prometheus and Grafana observability stack

### DIFF
--- a/k8s/observability/README.md
+++ b/k8s/observability/README.md
@@ -1,0 +1,143 @@
+# Observability Stack
+
+This directory contains the configuration for the k8s-ephemeral-environments observability stack.
+
+## Components
+
+| Component | Description | Status |
+|-----------|-------------|--------|
+| [kube-prometheus-stack](./kube-prometheus-stack/) | Prometheus, Grafana, Alertmanager | Deployed |
+| loki | Log aggregation | Planned (US-012) |
+| promtail | Log collection | Planned (US-012) |
+
+## Architecture
+
+```
+                                    ┌─────────────────────┐
+                                    │      Grafana        │
+                                    │  grafana.k8s-ee.    │
+                                    │   genesluna.dev     │
+                                    └─────────┬───────────┘
+                                              │
+                        ┌─────────────────────┼─────────────────────┐
+                        │                     │                     │
+                        ▼                     ▼                     ▼
+              ┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐
+              │   Prometheus    │   │      Loki       │   │  Alertmanager   │
+              │   (metrics)     │   │    (logs)       │   │   (alerts)      │
+              └────────┬────────┘   └────────┬────────┘   └─────────────────┘
+                       │                     │
+         ┌─────────────┼─────────────┐       │
+         │             │             │       │
+         ▼             ▼             ▼       ▼
+   ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐
+   │  node-    │ │  kube-    │ │   App     │ │ Promtail  │
+   │ exporter  │ │  state-   │ │  Pods     │ │ DaemonSet │
+   │ (nodes)   │ │  metrics  │ │           │ │ (logs)    │
+   └───────────┘ └───────────┘ └───────────┘ └───────────┘
+```
+
+## Quick Start
+
+### 1. Deploy Prometheus + Grafana
+
+See [kube-prometheus-stack/README.md](./kube-prometheus-stack/README.md) for detailed instructions.
+
+```bash
+# Prerequisites: Create GitHub OAuth App for Grafana
+
+# Create namespace
+kubectl create namespace observability
+
+# Create OAuth secrets (replace with your credentials)
+kubectl create secret generic grafana-oauth-secrets \
+  --namespace observability \
+  --from-literal=GF_AUTH_GITHUB_CLIENT_ID="<CLIENT_ID>" \
+  --from-literal=GF_AUTH_GITHUB_CLIENT_SECRET="<CLIENT_SECRET>"
+
+# Install kube-prometheus-stack
+helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace observability \
+  --values k8s/observability/kube-prometheus-stack/values.yaml \
+  --wait --timeout 10m
+
+# Apply Grafana ingress
+kubectl apply -f k8s/observability/grafana-ingress.yaml
+```
+
+### 2. Access Grafana
+
+- URL: https://grafana.k8s-ee.genesluna.dev
+- Authentication: GitHub OAuth only (password login disabled)
+- Access Control: Only members of the configured GitHub organization can login
+
+## Resource Budget
+
+The observability stack is designed to stay within ~4GB total memory:
+
+| Component | Memory Limit |
+|-----------|--------------|
+| Prometheus | 1536Mi |
+| Grafana | 256Mi |
+| Alertmanager | 64Mi |
+| node-exporter | 64Mi |
+| kube-state-metrics | 64Mi |
+| Prometheus Operator | 128Mi |
+| Loki (planned) | 1024Mi |
+| Promtail (planned) | 128Mi |
+| **Total** | **~3.3GB** |
+
+## Namespace
+
+All observability components are deployed to the `observability` namespace:
+
+```bash
+kubectl get all -n observability
+```
+
+## Monitoring Ephemeral PR Environments
+
+The Prometheus configuration is set to scrape all namespaces, including ephemeral PR namespaces (`*-pr-*`). This allows:
+
+- Automatic discovery of new PR environment pods
+- Metrics collection without additional configuration
+- Dashboard filtering by namespace
+
+To view metrics for a specific PR environment in Grafana:
+1. Open a dashboard
+2. Use the namespace filter dropdown
+3. Select the PR namespace (e.g., `k8s-ee-pr-42`)
+
+## Troubleshooting
+
+### Check Pod Status
+
+```bash
+kubectl get pods -n observability
+```
+
+### View Logs
+
+```bash
+# Prometheus
+kubectl logs -n observability -l app.kubernetes.io/name=prometheus --tail=100
+
+# Grafana
+kubectl logs -n observability -l app.kubernetes.io/name=grafana --tail=100
+
+# Alertmanager
+kubectl logs -n observability -l app.kubernetes.io/name=alertmanager --tail=100
+```
+
+### Port Forward for Debugging
+
+```bash
+# Prometheus UI
+kubectl port-forward -n observability svc/prometheus-kube-prometheus-prometheus 9090:9090
+
+# Grafana (alternative to ingress)
+kubectl port-forward -n observability svc/prometheus-grafana 3000:80
+
+# Alertmanager
+kubectl port-forward -n observability svc/prometheus-kube-prometheus-alertmanager 9093:9093
+```

--- a/k8s/observability/grafana-ingress.yaml
+++ b/k8s/observability/grafana-ingress.yaml
@@ -1,0 +1,32 @@
+# Grafana Ingress
+# Exposes Grafana at grafana.k8s-ee.genesluna.dev with TLS
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+    # Note: secretName omitted - Traefik provisions certificates automatically
+    # via the certresolver annotation (letsencrypt-prod)
+    - hosts:
+        - grafana.k8s-ee.genesluna.dev
+  rules:
+    - host: grafana.k8s-ee.genesluna.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus-grafana
+                port:
+                  number: 80

--- a/k8s/observability/grafana-oauth-secret.example.yaml
+++ b/k8s/observability/grafana-oauth-secret.example.yaml
@@ -1,0 +1,22 @@
+# Grafana OAuth Secrets
+# This file is a template - DO NOT commit actual credentials to git!
+#
+# To use this file:
+# 1. Copy to a local file: cp grafana-oauth-secret.example.yaml /tmp/grafana-oauth-secret.yaml
+# 2. Replace <YOUR_CLIENT_ID> and <YOUR_CLIENT_SECRET> with your GitHub OAuth App credentials
+# 3. Apply: kubectl apply -f /tmp/grafana-oauth-secret.yaml
+# 4. Delete the local file: rm /tmp/grafana-oauth-secret.yaml
+#
+# For production, consider using Sealed Secrets or external secret management.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-oauth-secrets
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: observability
+type: Opaque
+stringData:
+  GF_AUTH_GITHUB_CLIENT_ID: "<YOUR_CLIENT_ID>"
+  GF_AUTH_GITHUB_CLIENT_SECRET: "<YOUR_CLIENT_SECRET>"

--- a/k8s/observability/kube-prometheus-stack/README.md
+++ b/k8s/observability/kube-prometheus-stack/README.md
@@ -1,0 +1,212 @@
+# kube-prometheus-stack
+
+The kube-prometheus-stack provides a complete monitoring solution including Prometheus, Grafana, Alertmanager, and various exporters.
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| Prometheus | Metrics collection and storage |
+| Grafana | Visualization and dashboards |
+| Alertmanager | Alert routing and notifications |
+| node-exporter | Node-level metrics (CPU, memory, disk) |
+| kube-state-metrics | Kubernetes object metrics |
+| Prometheus Operator | CRD-based Prometheus management |
+
+## Prerequisites
+
+1. **GitHub Organization** for access control:
+   - Create a GitHub organization (e.g., `koder-cat`)
+   - Add team members who should have Grafana access
+
+2. **GitHub OAuth App** for Grafana authentication:
+   - Go to https://github.com/settings/developers
+   - Create new OAuth App with:
+     - Homepage URL: `https://grafana.k8s-ee.genesluna.dev`
+     - Callback URL: `https://grafana.k8s-ee.genesluna.dev/login/github`
+   - Save the Client ID and Client Secret
+
+## Installation
+
+```bash
+# Add the Helm repository
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+# Create the namespace
+kubectl create namespace observability
+
+# Create OAuth secrets (DO NOT commit actual credentials to git!)
+# Option 1: Create secret from template
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-oauth-secrets
+  namespace: observability
+type: Opaque
+stringData:
+  GF_AUTH_GITHUB_CLIENT_ID: "<YOUR_CLIENT_ID>"
+  GF_AUTH_GITHUB_CLIENT_SECRET: "<YOUR_CLIENT_SECRET>"
+EOF
+
+# Option 2: Create secret using kubectl
+kubectl create secret generic grafana-oauth-secrets \
+  --namespace observability \
+  --from-literal=GF_AUTH_GITHUB_CLIENT_ID="<YOUR_CLIENT_ID>" \
+  --from-literal=GF_AUTH_GITHUB_CLIENT_SECRET="<YOUR_CLIENT_SECRET>"
+
+# Install kube-prometheus-stack
+helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace observability \
+  --values k8s/observability/kube-prometheus-stack/values.yaml \
+  --wait --timeout 10m
+
+# Apply the Grafana ingress
+kubectl apply -f k8s/observability/grafana-ingress.yaml
+```
+
+## Verify Installation
+
+```bash
+# Check all pods are running
+kubectl get pods -n observability
+
+# Expected pods:
+# - prometheus-prometheus-kube-prometheus-prometheus-0
+# - prometheus-grafana-*
+# - prometheus-kube-prometheus-operator-*
+# - prometheus-kube-state-metrics-*
+# - prometheus-prometheus-node-exporter-*
+# - alertmanager-prometheus-kube-prometheus-alertmanager-0
+
+# Check Prometheus targets
+kubectl port-forward -n observability svc/prometheus-kube-prometheus-prometheus 9090:9090
+# Open http://localhost:9090/targets
+
+# Check Grafana
+kubectl port-forward -n observability svc/prometheus-grafana 3000:80
+# Open http://localhost:3000 (or use the ingress URL)
+```
+
+## Access
+
+| Service | URL | Notes |
+|---------|-----|-------|
+| Grafana | https://grafana.k8s-ee.genesluna.dev | GitHub OAuth only (password login disabled) |
+| Prometheus | Port-forward only | `kubectl port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090 -n observability` |
+| Alertmanager | Port-forward only | `kubectl port-forward svc/prometheus-kube-prometheus-alertmanager 9093:9093 -n observability` |
+
+**Authentication:** Only members of the configured GitHub organization can access Grafana. Password-based login is disabled for security.
+
+## Resource Usage
+
+| Component | Memory Request | Memory Limit |
+|-----------|----------------|--------------|
+| Prometheus | 512Mi | 1536Mi |
+| Grafana | 128Mi | 256Mi |
+| Alertmanager | 32Mi | 64Mi |
+| node-exporter | 32Mi | 64Mi |
+| kube-state-metrics | 32Mi | 64Mi |
+| Prometheus Operator | 64Mi | 128Mi |
+
+## Configuration
+
+### Adding ServiceMonitors
+
+To scrape metrics from your applications, create a ServiceMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: my-app
+  namespace: my-namespace
+  labels:
+    release: prometheus  # Must match the Helm release
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+  endpoints:
+    - port: metrics
+      interval: 30s
+```
+
+### Adding Custom Alerts
+
+Create a PrometheusRule resource:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: my-alerts
+  namespace: observability
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: my-alerts
+      rules:
+        - alert: HighMemoryUsage
+          expr: container_memory_usage_bytes > 1e9
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High memory usage detected"
+```
+
+## Upgrade
+
+```bash
+helm repo update
+helm upgrade prometheus prometheus-community/kube-prometheus-stack \
+  --namespace observability \
+  --values k8s/observability/kube-prometheus-stack/values.yaml \
+  --wait --timeout 10m
+```
+
+Note: OAuth credentials are stored in the `grafana-oauth-secrets` Kubernetes Secret and persist across upgrades.
+
+## Uninstallation
+
+```bash
+# Delete the Helm release
+helm uninstall prometheus -n observability
+
+# Delete PVCs (optional - removes all data)
+kubectl delete pvc -n observability -l app.kubernetes.io/instance=prometheus
+
+# Delete the namespace (optional)
+kubectl delete namespace observability
+```
+
+## Troubleshooting
+
+### Prometheus Not Scraping Targets
+
+1. Check ServiceMonitor labels match `release: prometheus`
+2. Verify the service has the correct port name
+3. Check Prometheus configuration: `kubectl get prometheus -n observability -o yaml`
+
+### Grafana Login Issues
+
+1. Verify GitHub OAuth App callback URL is correct
+2. Check Grafana logs: `kubectl logs -n observability -l app.kubernetes.io/name=grafana`
+3. Verify OAuth secrets exist: `kubectl get secret grafana-oauth-secrets -n observability`
+4. Verify your GitHub account is a member of the allowed organization (configured in `values.yaml` under `allowed_organizations`)
+5. If you see "not a member of required organizations" error, ensure you've joined the GitHub organization
+
+### High Memory Usage
+
+1. Reduce retention period in values.yaml
+2. Add more specific label selectors to reduce cardinality
+3. Check for high-cardinality metrics
+
+## References
+
+- [kube-prometheus-stack Chart](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack)
+- [Prometheus Operator Documentation](https://prometheus-operator.dev/)
+- [Grafana Documentation](https://grafana.com/docs/grafana/latest/)

--- a/k8s/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/observability/kube-prometheus-stack/values.yaml
@@ -1,0 +1,247 @@
+# kube-prometheus-stack Helm Values
+# Optimized for ARM64 VPS with limited resources
+# Includes Prometheus, Grafana, Alertmanager, and exporters
+
+# Global settings
+fullnameOverride: "prometheus"
+
+# =============================================================================
+# Prometheus Configuration
+# =============================================================================
+prometheus:
+  prometheusSpec:
+    # Retention: 7 days (6GB limit leaves 40% headroom for WAL/compaction)
+    retention: 7d
+    retentionSize: "6GB"
+
+    # Resource limits (target: <2GB RAM for Prometheus)
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1536Mi
+
+    # Storage configuration
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-path
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 10Gi
+
+    # Scrape all namespaces including ephemeral PR namespaces
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+
+    # Security context for ARM64
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 2000
+
+# =============================================================================
+# Alertmanager Configuration
+# =============================================================================
+alertmanager:
+  alertmanagerSpec:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-path
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 1Gi
+
+# =============================================================================
+# Grafana Configuration
+# =============================================================================
+grafana:
+  enabled: true
+
+  # Resource limits
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+  # Persistence for dashboards and settings
+  persistence:
+    enabled: true
+    storageClassName: local-path
+    size: 2Gi
+
+  # Disable init container that chowns data (not needed with local-path provisioner)
+  initChownData:
+    enabled: false
+
+  # Load OAuth credentials from Kubernetes Secret
+  # Secret must contain: GF_AUTH_GITHUB_CLIENT_ID and GF_AUTH_GITHUB_CLIENT_SECRET
+  envFromSecret: "grafana-oauth-secrets"
+
+  # Grafana configuration
+  grafana.ini:
+    server:
+      root_url: https://grafana.k8s-ee.genesluna.dev
+
+    # Security settings
+    security:
+      cookie_secure: true
+      cookie_samesite: strict
+      strict_transport_security: true
+      strict_transport_security_max_age_seconds: 15768000  # 6 months
+      x_content_type_options: true
+      x_xss_protection: true
+
+    # Disable anonymous access
+    auth.anonymous:
+      enabled: false
+
+    # Disable basic auth (password login)
+    auth.basic:
+      enabled: false
+
+    # Disable login form (only show OAuth buttons)
+    auth:
+      disable_login_form: true
+
+    # GitHub OAuth configuration
+    # Credentials loaded from envFromSecret (GF_AUTH_GITHUB_CLIENT_ID, GF_AUTH_GITHUB_CLIENT_SECRET)
+    auth.github:
+      enabled: true
+      allow_sign_up: true
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+      # Restrict access to koder-cat organization members
+      allowed_organizations: koder-cat
+
+  # Ingress disabled - we use separate IngressRoute
+  ingress:
+    enabled: false
+
+  # Sidecar for dashboard provisioning
+  sidecar:
+    dashboards:
+      enabled: true
+      searchNamespace: ALL
+    datasources:
+      enabled: true
+
+# =============================================================================
+# Node Exporter Configuration
+# =============================================================================
+nodeExporter:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+# Prometheus Node Exporter subchart
+prometheus-node-exporter:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+# =============================================================================
+# kube-state-metrics Configuration
+# =============================================================================
+kube-state-metrics:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+# =============================================================================
+# Prometheus Operator Configuration
+# =============================================================================
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+# =============================================================================
+# Disable k3s-incompatible Components
+# =============================================================================
+# k3s doesn't expose these metrics endpoints in the standard way
+kubeProxy:
+  enabled: false
+
+kubeEtcd:
+  enabled: false
+
+kubeScheduler:
+  enabled: false
+
+kubeControllerManager:
+  enabled: false
+
+# =============================================================================
+# Default Rules Configuration
+# =============================================================================
+defaultRules:
+  create: true
+  rules:
+    alertmanager: true
+    etcd: false
+    configReloaders: true
+    general: true
+    k8sContainerCpuUsageSecondsTotal: true
+    k8sContainerMemoryCache: true
+    k8sContainerMemoryRss: true
+    k8sContainerMemorySwap: true
+    k8sContainerResource: true
+    k8sPodOwner: true
+    kubeApiserverAvailability: true
+    kubeApiserverBurnrate: true
+    kubeApiserverHistogram: true
+    kubeApiserverSlos: true
+    kubeControllerManager: false
+    kubelet: true
+    kubeProxy: false
+    kubePrometheusGeneral: true
+    kubePrometheusNodeRecording: true
+    kubernetesApps: true
+    kubernetesResources: true
+    kubernetesStorage: true
+    kubernetesSystem: true
+    kubeSchedulerAlerting: false
+    kubeSchedulerRecording: false
+    kubeStateMetrics: true
+    network: true
+    node: true
+    nodeExporterAlerting: true
+    nodeExporterRecording: true
+    prometheus: true
+    prometheusOperator: true


### PR DESCRIPTION
## Summary

- Deploy kube-prometheus-stack for metrics collection and visualization
- Configure Grafana with GitHub OAuth authentication
- Add Traefik ingress for external Grafana access

## User Stories

- **US-011**: Deploy Prometheus for Metrics Collection
- **US-013**: Deploy Grafana Dashboards

## Changes

### New Files
- `k8s/observability/README.md` - Overview and quick start guide
- `k8s/observability/kube-prometheus-stack/values.yaml` - Helm values for ARM64 VPS
- `k8s/observability/kube-prometheus-stack/README.md` - Detailed installation guide
- `k8s/observability/grafana-ingress.yaml` - Traefik ingress with TLS
- `k8s/observability/grafana-oauth-secret.example.yaml` - Secret template

### Key Configuration
- **Prometheus**: 7-day retention, 6GB storage limit, ~512Mi-1.5GB RAM
- **Grafana**: GitHub OAuth with organization restriction (koder-cat), password login disabled
- **Security**: HSTS (6 months), secure cookies, XSS protection
- **Disabled**: k3s-incompatible monitors (kubeProxy, etcd, scheduler)
- **Secrets**: OAuth credentials stored in Kubernetes Secret (not --set flags)

### Security Features
- GitHub OAuth only (password login disabled)
- Organization-based access control (koder-cat)
- HSTS with 6-month max-age
- Secure cookie settings (SameSite=strict)
- XSS and content-type protection headers

## Verification

Deployed and verified on cluster:
- [x] All pods running in observability namespace
- [x] Grafana accessible at https://grafana.k8s-ee.genesluna.dev
- [x] GitHub OAuth login working (organization restriction)
- [x] Password login disabled
- [x] Prometheus collecting metrics from all namespaces
- [x] TLS working with Let's Encrypt certificate
- [x] Resource usage within budget (~1.1GB total)

## Test Plan

- [x] Login to Grafana with GitHub account
- [x] Verify Prometheus data source is configured (Prometheus + Alertmanager)
- [x] Check pre-built Kubernetes dashboards load correctly (24 dashboards)
- [x] Verify metrics from ephemeral PR namespaces are visible (k8s-ee-pr-36 confirmed)

Closes #11
Closes #13