### PR TITLE
feat(us-012): Add Loki and Promtail for log aggregation

### DIFF
--- a/docs/user-stories/epic-4-observability/US-012-deploy-loki.md
+++ b/docs/user-stories/epic-4-observability/US-012-deploy-loki.md
@@ -1,5 +1,7 @@
 # US-012: Deploy Loki for Log Aggregation
 
+**Status:** Done
+
 ## User Story
 
 **As a** developer,
@@ -8,11 +10,11 @@
 
 ## Acceptance Criteria
 
-- [ ] Loki deployed in `observability` namespace
-- [ ] Promtail collecting logs from all pods
-- [ ] Logs queryable by namespace/pod/container
-- [ ] Retention configured (7 days)
-- [ ] Resource usage < 2GB RAM
+- [x] Loki deployed in `observability` namespace
+- [x] Promtail collecting logs from all pods
+- [x] Logs queryable by namespace/pod/container
+- [x] Retention configured (7 days)
+- [x] Resource usage < 2GB RAM
 
 ## Priority
 

--- a/k8s/observability/README.md
+++ b/k8s/observability/README.md
@@ -7,8 +7,8 @@ This directory contains the configuration for the k8s-ephemeral-environments obs
 | Component | Description | Status |
 |-----------|-------------|--------|
 | [kube-prometheus-stack](./kube-prometheus-stack/) | Prometheus, Grafana, Alertmanager | Deployed |
-| loki | Log aggregation | Planned (US-012) |
-| promtail | Log collection | Planned (US-012) |
+| [loki](./loki/) | Log aggregation | Deployed |
+| [promtail](./promtail/) | Log collection | Deployed |
 
 ## Architecture
 
@@ -83,8 +83,8 @@ The observability stack is designed to stay within ~4GB total memory:
 | node-exporter | 64Mi |
 | kube-state-metrics | 64Mi |
 | Prometheus Operator | 128Mi |
-| Loki (planned) | 1024Mi |
-| Promtail (planned) | 128Mi |
+| Loki | 1024Mi |
+| Promtail | 128Mi |
 | **Total** | **~3.3GB** |
 
 ## Namespace
@@ -127,6 +127,12 @@ kubectl logs -n observability -l app.kubernetes.io/name=grafana --tail=100
 
 # Alertmanager
 kubectl logs -n observability -l app.kubernetes.io/name=alertmanager --tail=100
+
+# Loki
+kubectl logs -n observability -l app.kubernetes.io/name=loki --tail=100
+
+# Promtail
+kubectl logs -n observability -l app.kubernetes.io/name=promtail --tail=100
 ```
 
 ### Port Forward for Debugging

--- a/k8s/observability/kube-prometheus-stack/values.yaml
+++ b/k8s/observability/kube-prometheus-stack/values.yaml
@@ -145,6 +145,16 @@ grafana:
     datasources:
       enabled: true
 
+  # Additional data sources (Loki for logs)
+  # Using the gateway service which acts as a proxy to Loki
+  additionalDataSources:
+    - name: Loki
+      type: loki
+      url: http://loki-gateway.observability.svc.cluster.local
+      access: proxy
+      isDefault: false
+      editable: true
+
 # =============================================================================
 # Node Exporter Configuration
 # =============================================================================

--- a/k8s/observability/loki/README.md
+++ b/k8s/observability/loki/README.md
@@ -1,0 +1,160 @@
+# Loki
+
+Loki is a horizontally-scalable, highly-available log aggregation system. This deployment uses SingleBinary mode optimized for a single-node k3s cluster.
+
+## Overview
+
+| Setting | Value |
+|---------|-------|
+| Mode | SingleBinary |
+| Namespace | `observability` |
+| Storage | Filesystem (local-path PVC) |
+| Retention | 7 days |
+| Memory Limit | 1Gi |
+
+## Prerequisites
+
+- Helm 3.x
+- k3s cluster with `local-path` storage class
+- `observability` namespace created
+
+## Installation
+
+```bash
+# Add Grafana Helm repository
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+
+# Install Loki
+helm upgrade --install loki grafana/loki \
+  --namespace observability \
+  --values k8s/observability/loki/values.yaml \
+  --wait --timeout 5m
+```
+
+## Verify Installation
+
+```bash
+# Check pods are running
+kubectl get pods -n observability -l app.kubernetes.io/name=loki
+
+# Check Loki readiness
+kubectl exec -n observability loki-0 -- wget -qO- http://localhost:3100/ready
+
+# Check Loki metrics
+kubectl exec -n observability loki-0 -- wget -qO- http://localhost:3100/metrics | head -20
+```
+
+## Configuration
+
+### Key Settings
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `deploymentMode` | `SingleBinary` | All components in single process |
+| `loki.auth_enabled` | `false` | Single-tenant mode |
+| `loki.limits_config.retention_period` | `168h` | 7 days log retention |
+| `singleBinary.persistence.size` | `5Gi` | Storage for logs |
+| `singleBinary.resources.limits.memory` | `1Gi` | Memory limit |
+
+### Storage
+
+Loki stores data on a persistent volume using k3s's `local-path` provisioner:
+
+- **Location**: `/var/lib/rancher/k3s/storage/` on the node
+- **Size**: 5Gi
+- **Data**: Index and chunks stored in filesystem
+
+### Retention
+
+Retention is handled by the compactor:
+- Logs older than 7 days are automatically deleted
+- Compactor runs periodically to enforce retention
+- Storage is reclaimed after deletion
+
+## Querying Logs
+
+Logs can be queried through Grafana using LogQL:
+
+```logql
+# All logs from a namespace
+{namespace="observability"}
+
+# Logs from a specific pod
+{namespace="observability", pod="loki-0"}
+
+# Filter by log content
+{namespace="observability"} |= "error"
+
+# PR environment logs
+{namespace=~"k8s-ee-pr-.*"}
+```
+
+## Resource Usage
+
+| Component | Memory Request | Memory Limit |
+|-----------|----------------|--------------|
+| Loki SingleBinary | 256Mi | 1Gi |
+| Gateway | 32Mi | 64Mi |
+
+## Upgrade
+
+```bash
+helm repo update
+helm upgrade loki grafana/loki \
+  --namespace observability \
+  --values k8s/observability/loki/values.yaml \
+  --wait --timeout 5m
+```
+
+## Uninstallation
+
+```bash
+# Delete Helm release
+helm uninstall loki -n observability
+
+# Delete PVC (removes all log data)
+kubectl delete pvc -n observability -l app.kubernetes.io/name=loki
+```
+
+## Troubleshooting
+
+### Loki Not Ready
+
+```bash
+# Check pod status
+kubectl describe pod -n observability -l app.kubernetes.io/name=loki
+
+# Check logs
+kubectl logs -n observability -l app.kubernetes.io/name=loki --tail=100
+```
+
+### Storage Issues
+
+```bash
+# Check PVC status
+kubectl get pvc -n observability -l app.kubernetes.io/name=loki
+
+# Check disk usage on node
+ssh ubuntu@168.138.151.63 'df -h /var/lib/rancher/k3s/storage'
+```
+
+### High Memory Usage
+
+If Loki is using too much memory:
+
+1. Reduce retention period in `values.yaml`
+2. Lower ingestion rate limits
+3. Check for high-cardinality labels
+
+### No Logs Appearing
+
+1. Verify Promtail is running and sending logs
+2. Check Loki is accepting connections: `kubectl logs -n observability loki-0 | grep -i error`
+3. Verify Grafana Loki datasource URL is correct
+
+## References
+
+- [Loki Documentation](https://grafana.com/docs/loki/latest/)
+- [LogQL Query Language](https://grafana.com/docs/loki/latest/query/)
+- [Loki Helm Chart](https://github.com/grafana/loki/tree/main/production/helm/loki)

--- a/k8s/observability/loki/values.yaml
+++ b/k8s/observability/loki/values.yaml
@@ -1,0 +1,157 @@
+# Loki Helm Values
+# SingleBinary mode optimized for single-node ARM64 k3s cluster
+# Chart: grafana/loki
+
+# Consistent service naming for Promtail and Grafana datasource URLs
+fullnameOverride: loki
+
+# Deployment mode: SingleBinary runs all components in a single process
+# Ideal for small deployments up to ~20GB/day of logs
+deploymentMode: SingleBinary
+
+# =============================================================================
+# Loki Configuration
+# =============================================================================
+loki:
+  # Disable multi-tenancy for simpler single-tenant setup
+  auth_enabled: false
+
+  # Common configuration
+  commonConfig:
+    # Single replica, no replication needed
+    replication_factor: 1
+
+  # Storage configuration - filesystem for single-node
+  storage:
+    type: filesystem
+
+  # Schema configuration
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+
+  # Retention and limits
+  limits_config:
+    # 7 days retention
+    retention_period: 168h
+    # Ingestion limits
+    ingestion_rate_mb: 4
+    ingestion_burst_size_mb: 6
+    # Query limits
+    max_query_series: 500
+    max_entries_limit_per_query: 5000
+
+  # Compactor for retention enforcement
+  compactor:
+    retention_enabled: true
+    delete_request_store: filesystem
+    working_directory: /var/loki/compactor
+
+# =============================================================================
+# SingleBinary Configuration
+# =============================================================================
+singleBinary:
+  replicas: 1
+
+  # Persistence using k3s local-path provisioner
+  persistence:
+    enabled: true
+    storageClass: local-path
+    size: 5Gi
+
+  # Resource limits (target: < 1GB RAM)
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  # Pod security context
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+
+  # Container security context
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+# =============================================================================
+# Disable Distributed Components (not needed for SingleBinary)
+# =============================================================================
+read:
+  replicas: 0
+
+write:
+  replicas: 0
+
+backend:
+  replicas: 0
+
+# =============================================================================
+# Gateway Configuration
+# =============================================================================
+gateway:
+  # Disable anti-affinity for single-node cluster
+  affinity: {}
+
+  # Resource limits
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+  # Pod security context
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+
+  # Container security context
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+# =============================================================================
+# Disable Optional Components
+# =============================================================================
+# Disable monitoring features not needed for this setup
+monitoring:
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+  lokiCanary:
+    enabled: false
+
+# Disable test pod
+test:
+  enabled: false
+
+# Disable chunk cache (not needed for small deployments)
+chunksCache:
+  enabled: false
+
+# Disable results cache
+resultsCache:
+  enabled: false

--- a/k8s/observability/promtail/README.md
+++ b/k8s/observability/promtail/README.md
@@ -1,0 +1,183 @@
+# Promtail
+
+Promtail is a log shipping agent that collects logs from Kubernetes pods and sends them to Loki.
+
+## Overview
+
+| Setting | Value |
+|---------|-------|
+| Deployment | DaemonSet (one per node) |
+| Namespace | `observability` |
+| Log Source | `/var/log/pods`, `/var/log/containers` |
+| Target | Loki Gateway at `http://loki-gateway.observability.svc.cluster.local` |
+| Memory Limit | 128Mi |
+
+## Prerequisites
+
+- Helm 3.x
+- Loki deployed and running
+- `observability` namespace created
+
+## Installation
+
+```bash
+# Add Grafana Helm repository (if not already added)
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+
+# Install Promtail
+helm upgrade --install promtail grafana/promtail \
+  --namespace observability \
+  --values k8s/observability/promtail/values.yaml \
+  --wait --timeout 5m
+```
+
+## Verify Installation
+
+```bash
+# Check DaemonSet is running
+kubectl get daemonset -n observability promtail
+
+# Check pods are running on all nodes
+kubectl get pods -n observability -l app.kubernetes.io/name=promtail -o wide
+
+# Check Promtail logs
+kubectl logs -n observability -l app.kubernetes.io/name=promtail --tail=50
+```
+
+## Configuration
+
+### Labels Extracted
+
+Promtail extracts the following labels from Kubernetes metadata:
+
+| Label | Source |
+|-------|--------|
+| `namespace` | Pod namespace |
+| `pod` | Pod name |
+| `container` | Container name |
+| `node` | Node where pod runs |
+| `app` | `app` label on pod |
+| `app_name` | `app.kubernetes.io/name` label |
+| `component` | `app.kubernetes.io/component` label |
+| `job` | `namespace/pod` |
+
+### Log Paths
+
+k3s uses containerd which stores logs in:
+
+- `/var/log/pods/<namespace>_<pod>_<uid>/<container>/*.log`
+- `/var/log/containers/<pod>_<namespace>_<container>-<id>.log` (symlinks)
+
+Promtail mounts both paths to ensure complete log coverage.
+
+### Pipeline Stages
+
+The scrape configuration uses:
+
+1. **CRI stage**: Parses containerd/CRI log format
+2. **Relabel configs**: Extracts Kubernetes metadata as labels
+
+## Querying Logs with Labels
+
+Use the extracted labels in Grafana/LogQL:
+
+```logql
+# All logs from a namespace
+{namespace="default"}
+
+# Specific pod logs
+{namespace="observability", pod="loki-0"}
+
+# All containers in a pod
+{namespace="observability", pod=~"prometheus-.*"}
+
+# Filter by app label
+{app="demo-app"}
+
+# PR environment logs (regex match)
+{namespace=~"k8s-ee-pr-.*"}
+
+# Combine with text search
+{namespace="observability", container="loki"} |= "error"
+```
+
+## Resource Usage
+
+| Setting | Request | Limit |
+|---------|---------|-------|
+| CPU | 50m | 200m |
+| Memory | 64Mi | 128Mi |
+
+## Upgrade
+
+```bash
+helm repo update
+helm upgrade promtail grafana/promtail \
+  --namespace observability \
+  --values k8s/observability/promtail/values.yaml \
+  --wait --timeout 5m
+```
+
+## Uninstallation
+
+```bash
+helm uninstall promtail -n observability
+```
+
+## Troubleshooting
+
+### Promtail Not Collecting Logs
+
+```bash
+# Check Promtail is running
+kubectl get pods -n observability -l app.kubernetes.io/name=promtail
+
+# Check Promtail logs for errors
+kubectl logs -n observability -l app.kubernetes.io/name=promtail --tail=100
+
+# Verify log paths exist on node
+ssh ubuntu@168.138.151.63 'ls -la /var/log/pods/ | head -10'
+```
+
+### Logs Not Appearing in Loki
+
+1. Check Promtail can reach Loki:
+   ```bash
+   kubectl exec -n observability -l app.kubernetes.io/name=promtail -- wget -qO- http://loki-gateway.observability.svc.cluster.local/ready
+   ```
+
+2. Check for connection errors in Promtail logs:
+   ```bash
+   kubectl logs -n observability -l app.kubernetes.io/name=promtail | grep -i error
+   ```
+
+3. Verify Loki is accepting pushes:
+   ```bash
+   kubectl logs -n observability loki-0 | grep -i "push" | tail -10
+   ```
+
+### High Memory Usage
+
+If Promtail is using too much memory:
+
+1. Check for high log volume pods
+2. Consider adding drop rules for noisy logs
+3. Increase limits if justified
+
+### Missing Labels
+
+If expected labels are not appearing:
+
+1. Verify pod has the expected labels:
+   ```bash
+   kubectl get pod <pod-name> -n <namespace> -o yaml | grep -A10 labels
+   ```
+
+2. Check Promtail relabel configuration in values.yaml
+
+## References
+
+- [Promtail Documentation](https://grafana.com/docs/loki/latest/send-data/promtail/)
+- [Promtail Configuration](https://grafana.com/docs/loki/latest/send-data/promtail/configuration/)
+- [Promtail Helm Chart](https://github.com/grafana/helm-charts/tree/main/charts/promtail)

--- a/k8s/observability/promtail/values.yaml
+++ b/k8s/observability/promtail/values.yaml
@@ -1,0 +1,135 @@
+# Promtail Helm Values
+# DaemonSet configuration for k3s log collection
+# Chart: grafana/promtail
+
+# =============================================================================
+# Promtail Configuration
+# =============================================================================
+config:
+  # Loki endpoint using the gateway service (nginx proxy to Loki)
+  clients:
+    - url: http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push
+      # Retry configuration
+      backoff_config:
+        min_period: 500ms
+        max_period: 5m
+        max_retries: 10
+
+  # Server configuration
+  server:
+    http_listen_port: 3101
+
+  # Positions file for tracking log progress
+  positions:
+    filename: /run/promtail/positions.yaml
+
+  # Scrape configurations
+  scrapeConfigs:
+    # Scrape Kubernetes pod logs
+    - job_name: kubernetes-pods
+      kubernetes_sd_configs:
+        - role: pod
+      # Use CRI log format (k3s uses containerd)
+      pipeline_stages:
+        - cri: {}
+      relabel_configs:
+        # Keep only pods that are running
+        - source_labels: [__meta_kubernetes_pod_phase]
+          action: drop
+          regex: (Failed|Succeeded)
+
+        # Extract node name
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+
+        # Extract namespace
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+
+        # Extract pod name
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod
+
+        # Extract container name
+        - source_labels: [__meta_kubernetes_pod_container_name]
+          target_label: container
+
+        # Extract app label
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          target_label: app
+
+        # Extract app.kubernetes.io/name label
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+          target_label: app_name
+
+        # Extract app.kubernetes.io/component label
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+          target_label: component
+
+        # Set job name from namespace/pod
+        - action: replace
+          replacement: $1
+          separator: /
+          source_labels:
+            - __meta_kubernetes_namespace
+            - __meta_kubernetes_pod_name
+          target_label: job
+
+        # Map to log file path in /var/log/pods
+        - replacement: /var/log/pods/*$1/*.log
+          separator: /
+          source_labels:
+            - __meta_kubernetes_pod_uid
+            - __meta_kubernetes_pod_container_name
+          target_label: __path__
+
+# =============================================================================
+# Resource Limits
+# =============================================================================
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# =============================================================================
+# DaemonSet Configuration
+# =============================================================================
+# Tolerations to run on all nodes
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+# Security context
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# =============================================================================
+# Volume Mounts for k3s Log Access
+# =============================================================================
+# The Promtail Helm chart mounts /var/log/pods and /var/log/containers by default
+# which is what k3s/containerd uses - no extra configuration needed
+
+# =============================================================================
+# Service Account
+# =============================================================================
+serviceAccount:
+  create: true
+  name: promtail
+
+# RBAC for reading pods
+rbac:
+  create: true
+
+# =============================================================================
+# Monitoring
+# =============================================================================
+# Disable ServiceMonitor (Prometheus can scrape Promtail metrics if needed later)
+serviceMonitor:
+  enabled: false


### PR DESCRIPTION
## Summary

- Deploy Loki in SingleBinary mode for centralized log storage
- Deploy Promtail DaemonSet for log collection from all pods
- Configure Loki as Grafana data source for log queries
- 7-day log retention with filesystem storage (5Gi PVC)
- Security hardened with non-root containers and read-only filesystems

## Configuration

| Component | Memory Request | Memory Limit | Actual Usage |
|-----------|----------------|--------------|--------------|
| Loki SingleBinary | 256Mi | 1Gi | ~192Mi |
| Loki Gateway | 32Mi | 64Mi | ~12Mi |
| Promtail | 64Mi | 128Mi | ~42Mi |

## Files Changed

- `k8s/observability/loki/values.yaml` - Loki Helm values
- `k8s/observability/loki/README.md` - Loki documentation
- `k8s/observability/promtail/values.yaml` - Promtail Helm values
- `k8s/observability/promtail/README.md` - Promtail documentation
- `k8s/observability/kube-prometheus-stack/values.yaml` - Added Loki datasource
- `k8s/observability/README.md` - Updated component status

## Test plan

- [x] Loki pods running (`kubectl get pods -n observability -l app.kubernetes.io/name=loki`)
- [x] Promtail DaemonSet running (`kubectl get ds -n observability promtail`)
- [x] Logs being collected (verified via Loki API query)
- [x] Loki datasource accessible in Grafana
- [x] Resource usage within limits (`kubectl top pods -n observability`)

Closes #12

Closes #12