### PR TITLE
feat(us-021): Add /preserve command and complete Phase 1

### DIFF
--- a/.github/workflows/pr-environment.yml
+++ b/.github/workflows/pr-environment.yml
@@ -619,6 +619,7 @@ jobs:
           echo "NAMESPACE=${{ env.PROJECT_ID }}-pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
 
       - name: Delete namespace
+        id: delete
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
@@ -638,6 +639,19 @@ jobs:
 
             if [ -n "$REPO" ] && [ "$REPO" != "$GITHUB_REPOSITORY" ]; then
               echo "WARNING: Namespace $NAMESPACE belongs to different repository: $REPO, skipping deletion"
+              exit 0
+            fi
+
+            # Check for preserve label (US-021)
+            PRESERVE=$(kubectl get namespace "$NAMESPACE" \
+              -o jsonpath='{.metadata.labels.preserve}' 2>/dev/null || echo "")
+            if [ "$PRESERVE" = "true" ]; then
+              echo "PRESERVED=true" >> $GITHUB_OUTPUT
+              PRESERVE_UNTIL=$(kubectl get namespace "$NAMESPACE" \
+                -o jsonpath='{.metadata.annotations.k8s-ee/preserve-until}' 2>/dev/null || echo "unknown")
+              echo "INFO: Namespace $NAMESPACE has preserve=true label, skipping deletion"
+              echo "INFO: Preserve expires at: $PRESERVE_UNTIL"
+              echo "INFO: The namespace will be cleaned up by the preserve-expiry job after expiration"
               exit 0
             fi
 
@@ -669,21 +683,44 @@ jobs:
             const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19) + ' UTC';
             const merged = '${{ github.event.pull_request.merged }}' === 'true';
             const namespace = process.env.NAMESPACE || 'unknown';
+            const preserved = '${{ steps.delete.outputs.PRESERVED }}' === 'true';
 
-            const body = [
-              marker,
-              '## 🗑️ Preview Environment Destroyed',
-              '',
-              '| Property | Value |',
-              '|----------|-------|',
-              '| **Status** | 🏁 Cleaned up |',
-              `| **Namespace** | \`${namespace}\` |`,
-              `| **Merged** | ${merged ? 'Yes' : 'No'} |`,
-              `| **Destroyed** | ${timestamp} |`,
-              '',
-              '---',
-              '<sub>🤖 Managed by GitHub Actions</sub>',
-            ].join('\n');
+            let body;
+            if (preserved) {
+              body = [
+                marker,
+                '## 🔒 Preview Environment Preserved',
+                '',
+                '| Property | Value |',
+                '|----------|-------|',
+                '| **Status** | 🔒 Preserved |',
+                `| **Namespace** | \`${namespace}\` |`,
+                `| **Merged** | ${merged ? 'Yes' : 'No'} |`,
+                `| **PR Closed** | ${timestamp} |`,
+                '',
+                'The environment was preserved and will remain active until the preserve expires.',
+                '',
+                'The preserve-expiry job will clean it up automatically.',
+                '',
+                '---',
+                '<sub>🤖 Managed by GitHub Actions</sub>',
+              ].join('\n');
+            } else {
+              body = [
+                marker,
+                '## 🗑️ Preview Environment Destroyed',
+                '',
+                '| Property | Value |',
+                '|----------|-------|',
+                '| **Status** | 🏁 Cleaned up |',
+                `| **Namespace** | \`${namespace}\` |`,
+                `| **Merged** | ${merged ? 'Yes' : 'No'} |`,
+                `| **Destroyed** | ${timestamp} |`,
+                '',
+                '---',
+                '<sub>🤖 Managed by GitHub Actions</sub>',
+              ].join('\n');
+            }
 
             // Find existing comment (fetch up to 100 to handle busy PRs)
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/preserve-environment.yml
+++ b/.github/workflows/preserve-environment.yml
@@ -1,0 +1,299 @@
+name: Preserve Environment
+
+on:
+  issue_comment:
+    types: [created]
+
+# Prevent concurrent preserve operations on the same PR
+concurrency:
+  group: preserve-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+# Workflow-level environment variables for consistency
+env:
+  PROJECT_ID: "k8s-ee"
+  KUBECTL_VERSION: "v1.31.0"
+  MAX_PRESERVED_ENVIRONMENTS: 3
+  PRESERVE_DURATION_HOURS: 48
+
+jobs:
+  preserve:
+    name: Preserve PR Environment
+    # Only run on PR comments (not issues) that start with /preserve
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/preserve')
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            return {
+              number: pr.number,
+              state: pr.state,
+              head_sha: pr.head.sha,
+            };
+
+      - name: Check PR is open
+        env:
+          PR_STATE: ${{ fromJSON(steps.pr.outputs.result).state }}
+        run: |
+          if [ "$PR_STATE" != "open" ]; then
+            echo "ERROR: PR is not open (state: $PR_STATE)"
+            exit 1
+          fi
+
+      - name: Install kubectl
+        run: |
+          set -euo pipefail
+
+          # Install kubectl with SHA256 verification
+          curl --connect-timeout 10 --max-time 60 -fLO \
+            "https://dl.k8s.io/release/${{ env.KUBECTL_VERSION }}/bin/linux/arm64/kubectl"
+          curl --connect-timeout 10 --max-time 30 -fLO \
+            "https://dl.k8s.io/release/${{ env.KUBECTL_VERSION }}/bin/linux/arm64/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check --strict
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+          rm kubectl.sha256
+          kubectl version --client
+
+      - name: Set environment variables
+        env:
+          # Pass user-controlled input through env to prevent command injection
+          PRESERVED_BY: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+
+          # Validate PROJECT_ID format
+          if ! [[ "${{ env.PROJECT_ID }}" =~ ^[a-z0-9]([a-z0-9-]{0,18}[a-z0-9])?$ ]]; then
+            echo "ERROR: PROJECT_ID must be lowercase alphanumeric with hyphens, 1-20 chars"
+            exit 1
+          fi
+
+          PR_NUMBER="${{ github.event.issue.number }}"
+          NAMESPACE="${{ env.PROJECT_ID }}-pr-${PR_NUMBER}"
+
+          # Calculate preserve-until timestamp (48 hours from now)
+          PRESERVE_UNTIL=$(date -u -d "+${{ env.PRESERVE_DURATION_HOURS }} hours" +%Y-%m-%dT%H:%M:%SZ)
+          PRESERVE_UNTIL_HUMAN=$(date -u -d "+${{ env.PRESERVE_DURATION_HOURS }} hours" "+%Y-%m-%d %H:%M UTC")
+
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          echo "NAMESPACE=$NAMESPACE" >> $GITHUB_ENV
+          echo "PRESERVE_UNTIL=$PRESERVE_UNTIL" >> $GITHUB_ENV
+          echo "PRESERVE_UNTIL_HUMAN=$PRESERVE_UNTIL_HUMAN" >> $GITHUB_ENV
+          echo "PRESERVED_BY=$PRESERVED_BY" >> $GITHUB_ENV
+
+      - name: Check namespace exists
+        run: |
+          set -euo pipefail
+
+          if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+            echo "ERROR: Namespace $NAMESPACE does not exist"
+            echo "The PR environment may not have been deployed yet."
+            exit 1
+          fi
+
+          echo "Namespace $NAMESPACE exists"
+
+      - name: Check preserve quota
+        id: quota
+        run: |
+          set -euo pipefail
+
+          # Count namespaces with preserve=true label (excluding current namespace)
+          PRESERVED_COUNT=$(kubectl get namespaces -l preserve=true \
+            --no-headers 2>/dev/null | wc -l || echo "0")
+
+          # Check if current namespace is already preserved
+          CURRENT_PRESERVED=$(kubectl get namespace "$NAMESPACE" \
+            -o jsonpath='{.metadata.labels.preserve}' 2>/dev/null || echo "")
+
+          echo "Current preserved count: $PRESERVED_COUNT"
+          echo "Current namespace preserve status: $CURRENT_PRESERVED"
+
+          # If already preserved, allow extending
+          if [ "$CURRENT_PRESERVED" = "true" ]; then
+            echo "ALREADY_PRESERVED=true" >> $GITHUB_ENV
+            echo "Namespace is already preserved, will extend preservation"
+            exit 0
+          fi
+
+          # Check quota
+          if [ "$PRESERVED_COUNT" -ge "${{ env.MAX_PRESERVED_ENVIRONMENTS }}" ]; then
+            echo "QUOTA_EXCEEDED=true" >> $GITHUB_ENV
+            echo "ERROR: Maximum preserved environments (${{ env.MAX_PRESERVED_ENVIRONMENTS }}) reached"
+            exit 0
+          fi
+
+          echo "ALREADY_PRESERVED=false" >> $GITHUB_ENV
+          echo "QUOTA_EXCEEDED=false" >> $GITHUB_ENV
+
+      - name: Comment on quota exceeded
+        if: env.QUOTA_EXCEEDED == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = '<!-- k8s-ee-preserve -->';
+            const maxEnvs = process.env.MAX_PRESERVED_ENVIRONMENTS;
+
+            const body = [
+              marker,
+              '## :warning: Cannot Preserve Environment',
+              '',
+              `Maximum preserved environments (${maxEnvs}) already reached.`,
+              '',
+              'Please wait for an existing preserved environment to expire or be released.',
+              '',
+              '---',
+              '<sub>Managed by GitHub Actions</sub>',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });
+
+      - name: Fail on quota exceeded
+        if: env.QUOTA_EXCEEDED == 'true'
+        run: exit 1
+
+      - name: Apply preserve label
+        run: |
+          set -euo pipefail
+
+          echo "Applying preserve label and annotation to $NAMESPACE..."
+
+          # Add preserve=true label
+          kubectl label namespace "$NAMESPACE" preserve=true --overwrite
+
+          # Add preserve-until annotation (user passed through env for safety)
+          kubectl annotate namespace "$NAMESPACE" \
+            "k8s-ee/preserve-until=$PRESERVE_UNTIL" \
+            "k8s-ee/preserved-by=$PRESERVED_BY" \
+            "k8s-ee/preserve-warning-sent=false" \
+            --overwrite
+
+          echo "Namespace preserved until $PRESERVE_UNTIL"
+
+      - name: Comment on success
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = '<!-- k8s-ee-preserve -->';
+            const preserveUntil = process.env.PRESERVE_UNTIL_HUMAN;
+            const namespace = process.env.NAMESPACE;
+            const preservedBy = process.env.PRESERVED_BY;
+            const alreadyPreserved = process.env.ALREADY_PRESERVED === 'true';
+            const action = alreadyPreserved ? 'Extended' : 'Preserved';
+
+            const body = [
+              marker,
+              `## :lock: Environment ${action}`,
+              '',
+              '| Property | Value |',
+              '|----------|-------|',
+              `| **Namespace** | \`${namespace}\` |`,
+              `| **Expires** | ${preserveUntil} |`,
+              `| **Duration** | ${process.env.PRESERVE_DURATION_HOURS} hours |`,
+              `| **Preserved by** | @${preservedBy} |`,
+              '',
+              'The environment will **not** be destroyed when the PR is closed.',
+              '',
+              `After ${preserveUntil}, the preserve label will be removed and the cleanup job will delete it.`,
+              '',
+              'To extend preservation, comment `/preserve` again.',
+              '',
+              '---',
+              '<sub>Managed by GitHub Actions</sub>',
+            ].join('\n');
+
+            // Find existing preserve comment (fetch up to 100 to handle busy PRs)
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find(c => c.body.includes(marker));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body,
+              });
+              console.log(`Updated comment: ${existingComment.html_url}`);
+            } else {
+              const { data: newComment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+              console.log(`Created comment: ${newComment.html_url}`);
+            }
+
+      - name: Comment on failure
+        if: failure()
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = '<!-- k8s-ee-preserve -->';
+            const namespace = process.env.NAMESPACE || 'unknown';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              marker,
+              '## :x: Preserve Failed',
+              '',
+              '| Property | Value |',
+              '|----------|-------|',
+              `| **Namespace** | \`${namespace}\` |`,
+              '| **Status** | Failed |',
+              '',
+              `[View workflow logs](${runUrl})`,
+              '',
+              '---',
+              '<sub>Managed by GitHub Actions</sub>',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Preserve Environment"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Namespace | \`$NAMESPACE\` |"
+            echo "| PR Number | #$PR_NUMBER |"
+            echo "| Preserve Until | $PRESERVE_UNTIL_HUMAN |"
+            echo "| Already Preserved | ${ALREADY_PRESERVED:-false} |"
+            echo "| Quota Exceeded | ${QUOTA_EXCEEDED:-false} |"
+          } >> $GITHUB_STEP_SUMMARY || true

--- a/README.md
+++ b/README.md
@@ -43,7 +43,15 @@ Every Pull Request gets its own isolated environment:
 
 ## Project Status
 
-**Phase 1 (Current):** Building the platform on a single VPS server to validate the approach and workflow.
+**Phase 1:** ✅ Complete - Platform fully operational on a single VPS server.
+
+All 21 user stories implemented across 6 epics:
+- Infrastructure (k3s, DNS, TLS)
+- PR Environment Lifecycle (create, deploy, comment, destroy)
+- Database per PR (PostgreSQL, MongoDB, MinIO, Redis)
+- Observability (Prometheus, Loki, Grafana, alerts)
+- GitHub Runners (ARC self-hosted runners)
+- Security (quotas, network policies, cleanup job, preserve feature)
 
 **Phase 2 (Future):** Migrating to AWS for better scalability and integration with managed services.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,98 +1,98 @@
-# PRD: Plataforma de Ambientes Efêmeros em Kubernetes
+# PRD: Kubernetes Ephemeral Environments Platform
 
-**Versão:** 1.0
-**Data:** 28 de Dezembro de 2024
-**Autor:** Time de Engenharia
+**Version:** 1.0
+**Date:** December 28, 2024
+**Author:** Engineering Team
 **Status:** Draft
 
 ---
 
-## 1. Resumo Executivo
+## 1. Executive Summary
 
-Este documento descreve a implementação de uma plataforma de ambientes efêmeros por Pull Request, utilizando Kubernetes. Cada PR terá seu próprio ambiente isolado (aplicação + banco de dados + observabilidade), acessível via URL pública e destruído automaticamente ao fechar/mergear o PR.
+This document describes the implementation of a platform for ephemeral environments per Pull Request using Kubernetes. Each PR will have its own isolated environment (application + database + observability), accessible via public URL and automatically destroyed when the PR is closed/merged.
 
-O projeto será desenvolvido em duas fases: **Fase 1** com um protótipo em VPS (k3s) para validação do modelo operacional, seguido de **Fase 2** com migração para Amazon EKS.
-
----
-
-## 2. Problema
-
-| # | Problema | Impacto | Como Mediremos |
-|---|----------|---------|----------------|
-| 1 | Review demora porque não há URL pública para teste | Time-to-market elevado | % PRs com review < 4h |
-| 2 | Devs sobrescrevem ambiente de staging compartilhado | Defeitos escapam para produção | Nº de hotfixes pós-release |
-| 3 | Logs/métricas de PRs ficam espalhados | Debug lento e complexo | Tempo médio para localizar causa-raiz |
-| 4 | Infra de teste é criada manualmente | Ambientes inconsistentes | Nº de incidentes por diferença de config |
-| 5 | Revisores precisam rodar código localmente | Ciclo de feedback lento | Tempo médio de review |
+The project will be developed in two phases: **Phase 1** with a prototype on VPS (k3s) for operational model validation, followed by **Phase 2** with migration to Amazon EKS.
 
 ---
 
-## 3. Objetivos e Key Results (OKRs)
+## 2. Problem
 
-| Objetivo | Key Result |
-|----------|------------|
-| **O1.** Todo PR possui ambiente isolado | KR1.1: ≥ 95% dos PRs com URL entregue em < 10 min |
-| | KR1.2: Zero namespaces órfãos após 24h |
-| **O2.** Custos previsíveis | KR2.1: Gasto mensal VPS < US$ 120 |
-| **O3.** Automação completa | KR3.1: Pipeline 100% automatizada (zero intervenção manual) |
-| **O4.** Observabilidade centralizada | KR4.1: 100% dos pods com logs/métricas acessíveis no Grafana |
+| # | Problem | Impact | How We'll Measure |
+|---|---------|--------|-------------------|
+| 1 | Review is slow because there's no public URL for testing | Elevated time-to-market | % of PRs with review < 4h |
+| 2 | Devs overwrite shared staging environment | Defects escape to production | # of post-release hotfixes |
+| 3 | PR logs/metrics are scattered | Slow and complex debugging | Average time to locate root cause |
+| 4 | Test infrastructure is created manually | Inconsistent environments | # of incidents due to config differences |
+| 5 | Reviewers need to run code locally | Slow feedback cycle | Average review time |
 
 ---
 
-## 4. Usuários-Alvo
+## 3. Objectives and Key Results (OKRs)
 
-| Persona | Necessidade |
-|---------|-------------|
-| **Desenvolvedores** | URL de preview + logs para validar código antes do merge |
-| **QAs** | Ambiente estável e isolado para testes exploratórios |
-| **Tech Lead / PM** | Visão de custo, status e tempo de vida de cada ambiente |
-| **SRE / DevOps** | Garantir limpeza de recursos e estabilidade do cluster |
+| Objective | Key Result |
+|-----------|------------|
+| **O1.** Every PR has an isolated environment | KR1.1: ≥ 95% of PRs with URL delivered in < 10 min |
+| | KR1.2: Zero orphaned namespaces after 24h |
+| **O2.** Predictable costs | KR2.1: Monthly VPS spending < US$ 120 |
+| **O3.** Complete automation | KR3.1: 100% automated pipeline (zero manual intervention) |
+| **O4.** Centralized observability | KR4.1: 100% of pods with logs/metrics accessible in Grafana |
+
+---
+
+## 4. Target Users
+
+| Persona | Need |
+|---------|------|
+| **Developers** | Preview URL + logs to validate code before merge |
+| **QAs** | Stable and isolated environment for exploratory testing |
+| **Tech Lead / PM** | Visibility into cost, status, and lifetime of each environment |
+| **SRE / DevOps** | Ensure resource cleanup and cluster stability |
 
 ---
 
 ## 5. Stakeholders
 
-- **Tech Lead** — Definição arquitetural e validação técnica
-- **Time de Engenharia** — Desenvolvimento e operação
-- **DevOps / Plataforma** — Suporte e evolução da infraestrutura
+- **Tech Lead** — Architectural definition and technical validation
+- **Engineering Team** — Development and operation
+- **DevOps / Platform** — Infrastructure support and evolution
 
 ---
 
-## 6. Escopo
+## 6. Scope
 
-### 6.1 In Scope (Fase 1 - VPS)
+### 6.1 In Scope (Phase 1 - VPS)
 
-- Cluster k3s single-node em VPS
-- Namespace por PR com lifecycle automatizado via GitHub Actions
-- Banco de dados efêmero por PR (PostgreSQL em container ou schema dedicado)
-- Stack de observabilidade (Prometheus, Loki, Grafana)
-- GitHub Actions runners self-hosted no cluster
-- NetworkPolicies para isolamento entre PRs
-- Documentação de setup e operação
+- Single-node k3s cluster on VPS
+- Namespace per PR with automated lifecycle via GitHub Actions
+- Ephemeral database per PR (PostgreSQL in container or dedicated schema)
+- Observability stack (Prometheus, Loki, Grafana)
+- Self-hosted GitHub Actions runners in the cluster
+- NetworkPolicies for isolation between PRs
+- Setup and operation documentation
 
-### 6.2 Out of Scope (Fase 1)
+### 6.2 Out of Scope (Phase 1)
 
-- Alta disponibilidade (multi-node)
-- Autoscaling de nós ou runners
-- Benchmark de performance
+- High availability (multi-node)
+- Node or runner autoscaling
+- Performance benchmarking
 - Disaster recovery
-- Ambientes de produção
-- Integração com serviços gerenciados AWS (RDS, etc.)
+- Production environments
+- Integration with AWS managed services (RDS, etc.)
 
-### 6.3 Futuro (Fase 2 - EKS)
+### 6.3 Future (Phase 2 - EKS)
 
-- Migração para Amazon EKS com node groups (spot + on-demand)
-- RDS/Aurora por PR via Crossplane ou AWS Controllers
-- EFS com reclaimPolicy=Delete
-- OPA/Gatekeeper para políticas avançadas
-- Kubecost para gestão de custos
-- Multi-tenancy entre sistemas
+- Migration to Amazon EKS with node groups (spot + on-demand)
+- RDS/Aurora per PR via Crossplane or AWS Controllers
+- EFS with reclaimPolicy=Delete
+- OPA/Gatekeeper for advanced policies
+- Kubecost for cost management
+- Multi-tenancy between systems
 
 ---
 
-## 7. Arquitetura Proposta
+## 7. Proposed Architecture
 
-### 7.1 Visão Geral
+### 7.1 Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -102,7 +102,7 @@ O projeto será desenvolvido em duas fases: **Fase 1** com um protótipo em VPS 
 │  │                                                           │  │
 │  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐       │  │
 │  │  │observability│  │  gh-runners │  │ app-pr-123  │       │  │
-│  │  │             │  │             │  │  (efêmero)  │       │  │
+│  │  │             │  │             │  │ (ephemeral) │       │  │
 │  │  │ - Prometheus│  │ - Runner x2 │  │             │       │  │
 │  │  │ - Loki      │  │             │  │ - App Pod   │       │  │
 │  │  │ - Grafana   │  │             │  │ - DB Pod    │       │  │
@@ -110,23 +110,23 @@ O projeto será desenvolvido em duas fases: **Fase 1** com um protótipo em VPS 
 │  │                                                           │  │
 │  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐       │  │
 │  │  │ app-pr-456  │  │ app-pr-789  │  │   platform  │       │  │
-│  │  │  (efêmero)  │  │  (efêmero)  │  │  (sistema)  │       │  │
+│  │  │ (ephemeral) │  │ (ephemeral) │  │  (system)   │       │  │
 │  │  └─────────────┘  └─────────────┘  └─────────────┘       │  │
 │  └───────────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### 7.2 Estrutura de Namespaces
+### 7.2 Namespace Structure
 
-| Namespace | Propósito | Lifecycle |
-|-----------|-----------|-----------|
-| `kube-system` | Componentes do k3s | Permanente |
-| `observability` | Prometheus, Loki, Grafana | Permanente |
-| `gh-runners` | GitHub Actions self-hosted runners | Permanente |
-| `platform` | Componentes base compartilhados | Permanente |
-| `{project-id}-pr-{number}` | Ambiente efêmero por PR | Efêmero (PR lifecycle) |
+| Namespace | Purpose | Lifecycle |
+|-----------|---------|-----------|
+| `kube-system` | k3s components | Permanent |
+| `observability` | Prometheus, Loki, Grafana | Permanent |
+| `gh-runners` | GitHub Actions self-hosted runners | Permanent |
+| `platform` | Shared base components | Permanent |
+| `{project-id}-pr-{number}` | Ephemeral environment per PR | Ephemeral (PR lifecycle) |
 
-### 7.3 Fluxo de CI/CD
+### 7.3 CI/CD Flow
 
 ```
 ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
@@ -136,250 +136,250 @@ O projeto será desenvolvido em duas fases: **Fase 1** com um protótipo em VPS 
                                                          │
                                                          ▼
 ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
-│ PR Close │────▶│  GitHub  │────▶│  Delete  │◀────│  URL do  │
-│ or Merge │     │  Action  │     │Namespace │     │ Preview  │
+│ PR Close │────▶│  GitHub  │────▶│  Delete  │◀────│  Preview │
+│ or Merge │     │  Action  │     │Namespace │     │   URL    │
 └──────────┘     └──────────┘     └──────────┘     └──────────┘
 ```
 
 ---
 
-## 8. Requisitos Funcionais
+## 8. Functional Requirements
 
-### 8.1 Ambientes Efêmeros
+### 8.1 Ephemeral Environments
 
-| ID | Requisito | Prioridade |
-|----|-----------|------------|
-| RF-01 | Criar namespace automaticamente quando PR é aberto | Must |
-| RF-02 | Destruir namespace e volumes quando PR é fechado/mergeado (< 5 min) | Must |
-| RF-03 | URL única por PR: `https://{project-id}-pr-{number}.preview.dominio.com` | Must |
-| RF-04 | Re-deploy automático em push de novos commits | Must |
-| RF-05 | Comentário automático no PR com URL de preview e status | Should |
-| RF-06 | Aplicar ResourceQuota e LimitRange em namespaces de PR | Should |
-| RF-07 | Permitir "pin" de ambiente via label `preserve=true` (máx 48h) | Could |
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| RF-01 | Automatically create namespace when PR is opened | Must |
+| RF-02 | Destroy namespace and volumes when PR is closed/merged (< 5 min) | Must |
+| RF-03 | Unique URL per PR: `https://{project-id}-pr-{number}.preview.domain.com` | Must |
+| RF-04 | Automatic re-deploy on new commit push | Must |
+| RF-05 | Automatic comment on PR with preview URL and status | Should |
+| RF-06 | Apply ResourceQuota and LimitRange to PR namespaces | Should |
+| RF-07 | Allow environment "pin" via `preserve=true` label (max 48h) | Could |
 
-### 8.2 Banco de Dados
+### 8.2 Database
 
-| ID | Requisito | Prioridade |
-|----|-----------|------------|
-| RF-08 | Instância de banco isolada por PR | Must |
-| RF-09 | Credenciais exclusivas por PR armazenadas em Secrets | Must |
-| RF-10 | Destruição do banco junto com namespace | Must |
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| RF-08 | Isolated database instance per PR | Must |
+| RF-09 | Exclusive credentials per PR stored in Secrets | Must |
+| RF-10 | Database destruction along with namespace | Must |
 
-### 8.3 Observabilidade
+### 8.3 Observability
 
-| ID | Requisito | Prioridade |
-|----|-----------|------------|
-| RF-11 | Logs de todos os pods coletados pelo Loki | Must |
-| RF-12 | Métricas de CPU/memória/rede coletadas pelo Prometheus | Must |
-| RF-13 | Dashboards pré-configurados no Grafana | Should |
-| RF-14 | Alertas básicos (disco, memória, pod restarts) | Could |
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| RF-11 | Logs from all pods collected by Loki | Must |
+| RF-12 | CPU/memory/network metrics collected by Prometheus | Must |
+| RF-13 | Pre-configured dashboards in Grafana | Should |
+| RF-14 | Basic alerts (disk, memory, pod restarts) | Could |
 
 ### 8.4 GitHub Runners
 
-| ID | Requisito | Prioridade |
-|----|-----------|------------|
-| RF-15 | Runners auto-registrados no GitHub | Must |
-| RF-16 | Runners com acesso ao cluster via ServiceAccount | Must |
-| RF-17 | Runners com kubectl, helm, docker instalados | Must |
-| RF-18 | Runners efêmeros (um por job) via ARC | Should |
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| RF-15 | Auto-registered runners on GitHub | Must |
+| RF-16 | Runners with cluster access via ServiceAccount | Must |
+| RF-17 | Runners with kubectl, helm, docker installed | Must |
+| RF-18 | Ephemeral runners (one per job) via ARC | Should |
 
 ---
 
-## 9. Requisitos Não-Funcionais
+## 9. Non-Functional Requirements
 
 ### 9.1 Performance
 
-| ID | Requisito | Meta |
-|----|-----------|------|
-| RNF-01 | Tempo de criação de ambiente | ≤ 10 min (p95) |
-| RNF-02 | Tempo de destruição de namespace | < 5 min |
-| RNF-03 | Overhead do stack de observabilidade | < 6 GB RAM |
+| ID | Requirement | Target |
+|----|-------------|--------|
+| RNF-01 | Environment creation time | ≤ 10 min (p95) |
+| RNF-02 | Namespace destruction time | < 5 min |
+| RNF-03 | Observability stack overhead | < 6 GB RAM |
 
-### 9.2 Disponibilidade
+### 9.2 Availability
 
-| ID | Requisito | Meta |
-|----|-----------|------|
-| RNF-04 | Uptime do cluster (horário comercial) | ≥ 95% |
-| RNF-05 | Recuperação automática após reboot da VPS | Sim |
+| ID | Requirement | Target |
+|----|-------------|--------|
+| RNF-04 | Cluster uptime (business hours) | ≥ 95% |
+| RNF-05 | Automatic recovery after VPS reboot | Yes |
 
-### 9.3 Segurança
+### 9.3 Security
 
-| ID | Requisito | Meta |
-|----|-----------|------|
-| RNF-06 | Secrets nunca em plain text nos repos | 100% |
-| RNF-07 | Isolamento de rede entre PRs (NetworkPolicy) | Obrigatório |
-| RNF-08 | Tokens GitHub de curta duração | Sim |
-| RNF-09 | CIS Kubernetes Benchmark nível 1 | Sim |
+| ID | Requirement | Target |
+|----|-------------|--------|
+| RNF-06 | Secrets never in plain text in repos | 100% |
+| RNF-07 | Network isolation between PRs (NetworkPolicy) | Required |
+| RNF-08 | Short-lived GitHub tokens | Yes |
+| RNF-09 | CIS Kubernetes Benchmark level 1 | Yes |
 
-### 9.4 Capacidade
+### 9.4 Capacity
 
-| ID | Requisito | Meta |
-|----|-----------|------|
-| RNF-10 | PRs simultâneos suportados | ≥ 5 |
-| RNF-11 | Retenção de logs | 7 dias |
-| RNF-12 | Retenção de métricas | 7 dias |
-| RNF-13 | Limites por namespace PR | CPU ≤ 1 core, RAM ≤ 2 Gi, Storage ≤ 5 Gi |
-
----
-
-## 10. Stack Tecnológico
-
-| Componente | Tecnologia | Justificativa |
-|------------|------------|---------------|
-| **Kubernetes** | k3s | Leve, production-ready, ideal para single-node, inclui containerd |
-| **Ingress** | Traefik | Incluso no k3s, suporte nativo a Let's Encrypt |
-| **CI/CD** | GitHub Actions | Já utilizado pelo time, integração nativa |
-| **Logs** | Loki + Promtail | Leve, integração nativa com Grafana |
-| **Métricas** | Prometheus | Padrão de mercado, amplo ecossistema |
-| **Dashboards** | Grafana | Interface unificada para logs e métricas |
-| **Runners** | actions-runner-controller (ARC) | Runners efêmeros e escaláveis no cluster |
-| **DB Operator** | CloudNativePG | Gerencia lifecycle do PostgreSQL no cluster |
-| **Secrets** | Sealed Secrets | Segurança básica, secrets criptografados no git |
-| **Storage** | Local Path Provisioner | Simples, adequado para MVP usando NVMe da VPS |
-| **DNS** | Wildcard | `*.preview.dominio.com` → IP da VPS |
+| ID | Requirement | Target |
+|----|-------------|--------|
+| RNF-10 | Simultaneous PRs supported | ≥ 5 |
+| RNF-11 | Log retention | 7 days |
+| RNF-12 | Metric retention | 7 days |
+| RNF-13 | Limits per PR namespace | CPU ≤ 1 core, RAM ≤ 2 Gi, Storage ≤ 5 Gi |
 
 ---
 
-## 11. Decisões de Design
+## 10. Technology Stack
 
-| Tópico | Decisão | Racional |
-|--------|---------|----------|
-| **Runtime K8s** | k3s | Instala rápido, footprint pequeno, ideal para VPS |
-| **DB por PR** | PostgreSQL via CloudNativePG | Isolamento completo, lifecycle automatizado |
-| **Storage** | Local Path Provisioner | Evita complexidade de CSI; aceitável para MVP |
-| **DNS** | Wildcard `*.preview.dominio.com` | Evita criar registro DNS por PR |
-| **Secrets** | Sealed Secrets | Permite versionar secrets criptografados |
-| **Manifests** | Helm charts | Templating flexível, comunidade ampla |
-
----
-
-## 12. Fluxo de Usuário (Happy Path)
-
-1. Dev cria branch `feat/nova-funcionalidade` e abre PR
-2. GitHub Actions detecta evento `pull_request: opened`
-3. Pipeline cria namespace `{project-id}-pr-{number}` com ResourceQuota
-4. Deploy da aplicação com imagem `:<sha>` + banco de dados
-5. Ingress criado; URL `{project-id}-pr-{number}.preview.dominio.com` ativa
-6. Bot comenta no PR com URL de preview e link para Grafana
-7. Dev/QA/Reviewer testam e dão feedback
-8. Commits adicionais disparam re-deploy automático
-9. PR mergeado → Actions executa cleanup do namespace
-10. Dados do Loki/Prometheus mantidos por 7 dias para troubleshooting
+| Component | Technology | Justification |
+|-----------|------------|---------------|
+| **Kubernetes** | k3s | Lightweight, production-ready, ideal for single-node, includes containerd |
+| **Ingress** | Traefik | Included in k3s, native Let's Encrypt support |
+| **CI/CD** | GitHub Actions | Already used by the team, native integration |
+| **Logs** | Loki + Promtail | Lightweight, native Grafana integration |
+| **Metrics** | Prometheus | Industry standard, broad ecosystem |
+| **Dashboards** | Grafana | Unified interface for logs and metrics |
+| **Runners** | actions-runner-controller (ARC) | Ephemeral and scalable runners in the cluster |
+| **DB Operator** | CloudNativePG | Manages PostgreSQL lifecycle in the cluster |
+| **Secrets** | Sealed Secrets | Basic security, encrypted secrets in git |
+| **Storage** | Local Path Provisioner | Simple, adequate for MVP using VPS NVMe |
+| **DNS** | Wildcard | `*.preview.domain.com` → VPS IP |
 
 ---
 
-## 13. Métricas e SLIs
+## 11. Design Decisions
 
-### 13.1 Indicadores de Nível de Serviço (SLIs)
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| **K8s Runtime** | k3s | Fast install, small footprint, ideal for VPS |
+| **DB per PR** | PostgreSQL via CloudNativePG | Complete isolation, automated lifecycle |
+| **Storage** | Local Path Provisioner | Avoids CSI complexity; acceptable for MVP |
+| **DNS** | Wildcard `*.preview.domain.com` | Avoids creating DNS record per PR |
+| **Secrets** | Sealed Secrets | Allows versioning encrypted secrets |
+| **Manifests** | Helm charts | Flexible templating, large community |
 
-| SLI | Meta |
-|-----|------|
-| % de PRs com URL entregue em < 10 min | ≥ 95% |
-| % de namespaces removidos em < 5 min após close | ≥ 98% |
-| % de pods com métricas/logs coletados | ≥ 95% |
+---
 
-### 13.2 Métricas de Observabilidade
+## 12. User Flow (Happy Path)
+
+1. Dev creates branch `feat/new-feature` and opens PR
+2. GitHub Actions detects `pull_request: opened` event
+3. Pipeline creates namespace `{project-id}-pr-{number}` with ResourceQuota
+4. Deploys application with image `:<sha>` + database
+5. Ingress created; URL `{project-id}-pr-{number}.preview.domain.com` active
+6. Bot comments on PR with preview URL and Grafana link
+7. Dev/QA/Reviewer test and give feedback
+8. Additional commits trigger automatic re-deploy
+9. PR merged → Actions executes namespace cleanup
+10. Loki/Prometheus data retained for 7 days for troubleshooting
+
+---
+
+## 13. Metrics and SLIs
+
+### 13.1 Service Level Indicators (SLIs)
+
+| SLI | Target |
+|-----|--------|
+| % of PRs with URL delivered in < 10 min | ≥ 95% |
+| % of namespaces removed in < 5 min after close | ≥ 98% |
+| % of pods with metrics/logs collected | ≥ 95% |
+
+### 13.2 Observability Metrics
 
 ```promql
-# Tempo de provisionamento
+# Provisioning time
 github_actions_workflow_run_duration_seconds{job="provision"}
 
-# Uso de recursos vs alocado
+# Resource usage vs allocated
 kube_pod_container_resource_requests / node_allocatable
 
-# Disponibilidade do API server
+# API server availability
 up{job="kubernetes-apiservers"}
 
-# Uso de disco
+# Disk usage
 node_filesystem_avail_bytes / node_filesystem_size_bytes
 ```
 
 ---
 
-## 14. Riscos e Mitigações
+## 14. Risks and Mitigations
 
-| Risco | Probabilidade | Impacto | Mitigação |
-|-------|---------------|---------|-----------|
-| VPS sem recursos suficientes | Baixa | Alto | Monitorar uso; limitar PRs simultâneos; ResourceQuotas |
-| Exaustão de disco (logs/imagens) | Média | Alto | Retention agressivo (3-7 dias); alertas em 80%; job limpeza de imagens |
-| Namespace órfão não deletado | Média | Baixo | Job de cleanup periódico; alertas |
-| Downtime da VPS | Média | Médio | Snapshot diário; runbook de recovery < 30 min |
-| "Pin" esquecido esgota recursos | Baixa | Médio | Cron remove `preserve` após 48h; quota máx 3 pinados |
-| Container escape | Baixa | Alto | NetworkPolicy default deny; PodSecurityStandard restricted |
-| Token GitHub comprometido | Baixa | Alto | Tokens curta duração; rotação periódica |
-
----
-
-## 15. Roadmap de Implementação
-
-### Fase 1: Foundation
-
-| Tarefa | Entrega |
-|--------|---------|
-| Provisionar VPS | VPS acessível via SSH |
-| Instalar e configurar k3s | Cluster funcional |
-| Configurar DNS wildcard | `*.preview.dominio.com` |
-| Documentar acesso ao cluster | Runbook de acesso |
-
-### Fase 2: CI/CD Pipeline
-
-| Tarefa | Entrega |
-|--------|---------|
-| Workflow de PR open | Namespace criado automaticamente |
-| Workflow de PR close | Namespace destruído automaticamente |
-| Configurar kubeconfig no GitHub | Actions com acesso ao cluster |
-| Comentário automático no PR | URL de preview no PR |
-
-### Fase 3: Observability
-
-| Tarefa | Entrega |
-|--------|---------|
-| Deploy do Prometheus | Métricas coletadas |
-| Deploy do Loki + Promtail | Logs centralizados |
-| Deploy do Grafana | Dashboards acessíveis |
-| Criar dashboards básicos | Visão geral do cluster |
-| Configurar alertas | Alertas de disco/memória |
-
-### Fase 4: Runners & Polish
-
-| Tarefa | Entrega |
-|--------|---------|
-| Deploy de GH runners no cluster | Runners operacionais |
-| Configurar ResourceQuotas | Limites por namespace |
-| Configurar NetworkPolicies | Isolamento entre PRs |
-| Testes com PRs simultâneos | Validação de capacidade |
-| Documentação final | Runbooks completos |
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| VPS without sufficient resources | Low | High | Monitor usage; limit simultaneous PRs; ResourceQuotas |
+| Disk exhaustion (logs/images) | Medium | High | Aggressive retention (3-7 days); alerts at 80%; image cleanup job |
+| Orphaned namespace not deleted | Medium | Low | Periodic cleanup job; alerts |
+| VPS downtime | Medium | Medium | Daily snapshot; recovery runbook < 30 min |
+| Forgotten "pin" exhausts resources | Low | Medium | Cron removes `preserve` after 48h; max quota of 3 pinned |
+| Container escape | Low | High | Default deny NetworkPolicy; restricted PodSecurityStandard |
+| Compromised GitHub token | Low | High | Short-lived tokens; periodic rotation |
 
 ---
 
-## 16. Critérios de Aceitação
+## 15. Implementation Roadmap
 
-O protótipo será considerado bem-sucedido quando:
+### Phase 1: Foundation
 
-- [ ] PR aberto cria ambiente automaticamente sem intervenção manual
-- [ ] PR fechado/mergeado destrói ambiente em < 5 min
-- [ ] ≥ 5 devs conseguem abrir PR e acessar URL sem suporte
-- [ ] Tempo médio de provisionamento ≤ 10 min (p95 ≤ 15 min)
-- [ ] Nenhum pod consegue pingar pod de outro namespace (teste e2e)
-- [ ] Grafana exibe logs e métricas de ≥ 95% dos pods
-- [ ] Disco volta ao nível pré-PR após destruição do namespace
-- [ ] Custo mensal ≤ US$ 120 com operação normal
-- [ ] 2 semanas de operação sem incidentes críticos
+| Task | Deliverable |
+|------|-------------|
+| Provision VPS | VPS accessible via SSH |
+| Install and configure k3s | Functional cluster |
+| Configure wildcard DNS | `*.preview.domain.com` |
+| Document cluster access | Access runbook |
+
+### Phase 2: CI/CD Pipeline
+
+| Task | Deliverable |
+|------|-------------|
+| PR open workflow | Namespace automatically created |
+| PR close workflow | Namespace automatically destroyed |
+| Configure kubeconfig on GitHub | Actions with cluster access |
+| Automatic PR comment | Preview URL on PR |
+
+### Phase 3: Observability
+
+| Task | Deliverable |
+|------|-------------|
+| Deploy Prometheus | Metrics collected |
+| Deploy Loki + Promtail | Centralized logs |
+| Deploy Grafana | Dashboards accessible |
+| Create basic dashboards | Cluster overview |
+| Configure alerts | Disk/memory alerts |
+
+### Phase 4: Runners & Polish
+
+| Task | Deliverable |
+|------|-------------|
+| Deploy GH runners in cluster | Operational runners |
+| Configure ResourceQuotas | Limits per namespace |
+| Configure NetworkPolicies | Isolation between PRs |
+| Test with simultaneous PRs | Capacity validation |
+| Final documentation | Complete runbooks |
 
 ---
 
-## 17. Decisões em Aberto
+## 16. Acceptance Criteria
 
-| Item | Opções | Status |
-|------|--------|--------|
-| Estratégia de banco | CloudNativePG vs. schema por PR em DB externo | A definir |
-| Domínio para preview | Subdomínio próprio vs. nip.io | A definir |
-| Política de retenção pós-PR | Destruir imediato vs. manter dados 24h | A definir |
-| Grafana SSO | Basic auth vs. GitHub OAuth | A definir |
+The prototype will be considered successful when:
+
+- [ ] Opened PR creates environment automatically without manual intervention
+- [ ] Closed/merged PR destroys environment in < 5 min
+- [ ] ≥ 5 devs can open PR and access URL without support
+- [ ] Average provisioning time ≤ 10 min (p95 ≤ 15 min)
+- [ ] No pod can ping pod from another namespace (e2e test)
+- [ ] Grafana displays logs and metrics from ≥ 95% of pods
+- [ ] Disk returns to pre-PR level after namespace destruction
+- [ ] Monthly cost ≤ US$ 120 with normal operation
+- [ ] 2 weeks of operation without critical incidents
 
 ---
 
-## 18. Referências
+## 17. Open Decisions
+
+| Item | Options | Status |
+|------|---------|--------|
+| Database strategy | CloudNativePG vs. schema per PR in external DB | To be defined |
+| Preview domain | Own subdomain vs. nip.io | To be defined |
+| Post-PR retention policy | Destroy immediately vs. keep data 24h | To be defined |
+| Grafana SSO | Basic auth vs. GitHub OAuth | To be defined |
+
+---
+
+## 18. References
 
 - [k3s Documentation](https://docs.k3s.io/)
 - [GitHub Actions: Self-hosted Runners](https://docs.github.com/en/actions/hosting-your-own-runners)
@@ -391,59 +391,59 @@ O protótipo será considerado bem-sucedido quando:
 
 ---
 
-## Apêndice A: Infraestrutura Provisionada
+## Appendix A: Provisioned Infrastructure
 
-### A.1 VPS - Detalhes
+### A.1 VPS - Details
 
-| Atributo | Valor |
-|----------|-------|
-| **Provedor** | Oracle Cloud Infrastructure (OCI) |
-| **IP Público** | `168.138.151.63` |
+| Attribute | Value |
+|-----------|-------|
+| **Provider** | Oracle Cloud Infrastructure (OCI) |
+| **Public IP** | `168.138.151.63` |
 | **Hostname** | `genilda` |
-| **Usuário SSH** | `ubuntu` |
-| **Porta SSH** | `22` |
+| **SSH User** | `ubuntu` |
+| **SSH Port** | `22` |
 | **OS** | Ubuntu 24.04.3 LTS (Noble Numbat) |
 | **Kernel** | 6.14.0-1018-oracle |
-| **Arquitetura** | ARM64 (aarch64) |
+| **Architecture** | ARM64 (aarch64) |
 
-### A.2 Recursos de Hardware
+### A.2 Hardware Resources
 
-| Recurso | Especificação |
-|---------|---------------|
+| Resource | Specification |
+|----------|---------------|
 | **vCPUs** | 4 |
 | **RAM** | 24 GB |
-| **Disco** | 96 GB (/) |
+| **Disk** | 96 GB (/) |
 | **Swap** | 2 GB |
 
-### A.3 Acesso SSH
+### A.3 SSH Access
 
 ```bash
 ssh ubuntu@168.138.151.63
 ```
 
-### A.4 Considerações ARM64
+### A.4 ARM64 Considerations
 
-A VPS utiliza arquitetura ARM64. Todas as imagens de container devem ser multi-arch ou ter builds específicos para `linux/arm64`:
+The VPS uses ARM64 architecture. All container images must be multi-arch or have specific builds for `linux/arm64`:
 
-- ✅ k3s: Suporte nativo ARM64
+- ✅ k3s: Native ARM64 support
 - ✅ Traefik: Multi-arch
 - ✅ Prometheus/Grafana/Loki: Multi-arch
-- ⚠️ Imagens da aplicação: Verificar/buildar para ARM64
+- ⚠️ Application images: Verify/build for ARM64
 
 ---
 
-## Histórico de Revisões
+## Revision History
 
-| Versão | Data | Autor | Alterações |
-|--------|------|-------|------------|
-| 1.1 | 28/12/2024 | Time de Engenharia | Adicionado Apêndice A com detalhes da VPS provisionada |
-| 1.0 | 28/12/2024 | Time de Engenharia | Versão inicial (consolidação de 4 PRDs) |
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.1 | 12/28/2024 | Engineering Team | Added Appendix A with provisioned VPS details |
+| 1.0 | 12/28/2024 | Engineering Team | Initial version (consolidation of 4 PRDs) |
 
 ---
 
-## Aprovações
+## Approvals
 
-| Papel | Nome | Data | Assinatura |
-|-------|------|------|------------|
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
 | Tech Lead | | | |
 | Engineering Manager | | | |

--- a/docs/runbooks/preserve-environment.md
+++ b/docs/runbooks/preserve-environment.md
@@ -1,0 +1,203 @@
+# Runbook: Preserve Environment Feature
+
+## Overview
+
+This runbook covers operations for the preserve environment feature, which allows
+developers to keep PR environments active for extended testing (up to 48 hours).
+
+## Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Preserve Workflow | `.github/workflows/preserve-environment.yml` | Handles `/preserve` command |
+| Expiry CronJob | `k8s/platform/preserve-expiry/` | Checks and expires preservations |
+| Alerts | `k8s/platform/alerts/preserve-alerts.yaml` | Monitoring alerts |
+
+## Common Operations
+
+### List Preserved Environments
+
+```bash
+kubectl get namespaces -l preserve=true
+```
+
+### Check Expiry Times
+
+```bash
+kubectl get namespaces -l preserve=true \
+  -o custom-columns='NAMESPACE:.metadata.name,EXPIRES:.metadata.annotations.k8s-ee/preserve-until,PRESERVED-BY:.metadata.annotations.k8s-ee/preserved-by'
+```
+
+### Manually Preserve a Namespace
+
+```bash
+NAMESPACE="k8s-ee-pr-123"
+PRESERVE_UNTIL=$(date -u -d "+48 hours" +%Y-%m-%dT%H:%M:%SZ)
+
+kubectl label namespace "$NAMESPACE" preserve=true --overwrite
+kubectl annotate namespace "$NAMESPACE" \
+  "k8s-ee/preserve-until=$PRESERVE_UNTIL" \
+  "k8s-ee/preserved-by=manual" \
+  --overwrite
+```
+
+### Manually Remove Preservation
+
+```bash
+kubectl label namespace <namespace> preserve-
+kubectl annotate namespace <namespace> k8s-ee/preserve-until-
+kubectl annotate namespace <namespace> k8s-ee/preserved-by-
+kubectl annotate namespace <namespace> k8s-ee/preserve-warning-sent-
+```
+
+### Run Expiry Check Manually
+
+```bash
+kubectl create job --from=cronjob/preserve-expiry manual-expiry -n platform
+kubectl logs -n platform job/manual-expiry -f
+```
+
+## Alert Response
+
+### PreserveExpiryJobFailed
+
+**Severity:** Warning
+
+**Symptoms:**
+- Preserved environments not expiring on schedule
+- No warning comments posted before expiry
+
+**Investigation:**
+
+1. Check recent job runs:
+   ```bash
+   kubectl get jobs -n platform -l app.kubernetes.io/name=preserve-expiry
+   ```
+
+2. Check job logs:
+   ```bash
+   kubectl logs -n platform -l app.kubernetes.io/name=preserve-expiry --tail=100
+   ```
+
+3. Check for pod issues:
+   ```bash
+   kubectl describe pod -n platform -l app.kubernetes.io/name=preserve-expiry
+   ```
+
+**Resolution:**
+
+1. If GitHub token issue:
+   ```bash
+   kubectl get secret github-cleanup-token -n platform
+   ```
+
+2. If image pull issue:
+   ```bash
+   kubectl describe pod -n platform -l app.kubernetes.io/name=preserve-expiry | grep -A5 Events
+   ```
+
+3. Manually run expiry check:
+   ```bash
+   kubectl create job --from=cronjob/preserve-expiry fix-expiry -n platform
+   ```
+
+### PreserveExpiryJobNotRunning
+
+**Severity:** Warning
+
+**Symptoms:**
+- CronJob hasn't run for over 2 hours
+
+**Investigation:**
+
+1. Check CronJob status:
+   ```bash
+   kubectl get cronjob preserve-expiry -n platform
+   kubectl describe cronjob preserve-expiry -n platform
+   ```
+
+2. Check if CronJob is suspended:
+   ```bash
+   kubectl get cronjob preserve-expiry -n platform -o jsonpath='{.spec.suspend}'
+   ```
+
+**Resolution:**
+
+1. If suspended, resume:
+   ```bash
+   kubectl patch cronjob preserve-expiry -n platform -p '{"spec":{"suspend":false}}'
+   ```
+
+2. Trigger manual run:
+   ```bash
+   kubectl create job --from=cronjob/preserve-expiry manual-run -n platform
+   ```
+
+### TooManyPreservedEnvironments
+
+**Severity:** Warning
+
+**Symptoms:**
+- More than 3 preserved environments exist
+- Quota enforcement may have failed
+
+**Investigation:**
+
+1. List all preserved environments:
+   ```bash
+   kubectl get namespaces -l preserve=true
+   ```
+
+2. Check when they expire:
+   ```bash
+   kubectl get namespaces -l preserve=true \
+     -o jsonpath='{range .items[*]}{.metadata.name}: {.metadata.annotations.k8s-ee/preserve-until}{"\n"}{end}'
+   ```
+
+**Resolution:**
+
+1. Wait for oldest preservations to expire, OR
+
+2. Manually remove preservation from oldest:
+   ```bash
+   kubectl label namespace <oldest-namespace> preserve-
+   ```
+
+## Metrics
+
+The preserve expiry job logs metrics at the end of each run:
+
+- `namespaces_checked` - Number of preserved namespaces checked
+- `namespaces_expired` - Number of preservations that expired
+- `namespaces_warned` - Number of warning comments sent
+- `comments_posted` - Total GitHub comments posted
+- `errors` - Number of errors encountered
+
+## Architecture
+
+```
+User comments "/preserve"
+        ↓
+preserve-environment.yml workflow
+  ├── Check PR is open
+  ├── Check namespace exists
+  ├── Check quota (max 3)
+  ├── Apply preserve=true label
+  ├── Apply k8s-ee/preserve-until annotation
+  └── Post confirmation comment
+        ↓
+preserve-expiry CronJob (hourly)
+  ├── List namespaces with preserve=true
+  ├── Check k8s-ee/preserve-until annotation
+  ├── If < 1 hour remaining → Post warning comment
+  └── If expired → Remove preserve label
+        ↓
+cleanup-orphaned-namespaces CronJob (every 6 hours)
+  └── Deletes namespaces without preserve=true label
+```
+
+## Related Documentation
+
+- [Cleanup Job Runbook](./cleanup-job.md)
+- [Preserve Feature README](../../k8s/platform/preserve-expiry/README.md)
+- [US-021 User Story](../user-stories/epic-6-security/US-021-preserve-environment.md)

--- a/docs/tasks/epic-6/US-021-tasks.md
+++ b/docs/tasks/epic-6/US-021-tasks.md
@@ -1,24 +1,28 @@
 # Tasks for US-021: Preserve Environment Feature
 
+**Status:** All tasks complete
+
 ## Tasks
 
-### T-021.1: Modify Cleanup Workflow
+### T-021.1: Modify Cleanup Workflow ✅
 - **Description:** Update cleanup to check for preserve label
 - **Acceptance Criteria:**
   - Check namespace for `preserve=true` label
   - Skip cleanup if label present
   - Log that cleanup was skipped
 - **Estimate:** S
+- **Implementation:** Done in US-020 (cleanup job respects preserve=true label)
 
-### T-021.2: Implement Preserve Label Application
+### T-021.2: Implement Preserve Label Application ✅
 - **Description:** Allow setting preserve label via PR comment
 - **Acceptance Criteria:**
   - Comment `/preserve` adds label to namespace
   - Label applied with timestamp annotation
   - Confirmation comment posted
 - **Estimate:** M
+- **Implementation:** `.github/workflows/preserve-environment.yml`
 
-### T-021.3: Create Preserve Expiry Job
+### T-021.3: Create Preserve Expiry Job ✅
 - **Description:** CronJob to remove expired preserve labels
 - **Acceptance Criteria:**
   - Runs hourly
@@ -26,30 +30,45 @@
   - Removes label after 48 hours
   - Triggers cleanup for expired namespaces
 - **Estimate:** M
+- **Implementation:** `k8s/platform/preserve-expiry/preserve-expiry-cronjob.yaml`
 
-### T-021.4: Implement Preserve Quota
+### T-021.4: Implement Preserve Quota ✅
 - **Description:** Limit number of preserved environments
 - **Acceptance Criteria:**
   - Maximum 3 preserved at a time
   - Reject preserve request if quota reached
   - Clear error message to user
 - **Estimate:** S
+- **Implementation:** Quota check in preserve workflow
 
-### T-021.5: Add Preserve Warning Comment
+### T-021.5: Add Preserve Warning Comment ✅
 - **Description:** Notify user when preserve expires
 - **Acceptance Criteria:**
   - Comment posted 1 hour before expiry
   - Comment posted when preserve removed
   - Instructions for extending included
 - **Estimate:** S
+- **Implementation:** Warning logic in expiry script
 
-### T-021.6: Document Preserve Feature
+### T-021.6: Document Preserve Feature ✅
 - **Description:** Create user documentation
 - **Acceptance Criteria:**
   - How to preserve documented
   - Limits documented
   - Examples provided
 - **Estimate:** S
+- **Implementation:**
+  - `k8s/platform/preserve-expiry/README.md`
+  - `docs/runbooks/preserve-environment.md`
+
+---
+
+## Additional Implementation Notes
+
+- Preserve workflow triggered by `issue_comment` event on `/preserve` command
+- Expiry job reuses `cleanup-job-sa` ServiceAccount and `github-cleanup-token` Secret
+- Uses `bitnami/kubectl:latest` for ARM64 compatibility
+- PrometheusRule alerts in `k8s/platform/alerts/preserve-alerts.yaml`
 
 ---
 

--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -8,64 +8,67 @@ This document provides an index of all user stories derived from the PRD.
 |--------|-------|
 | Total Epics | 6 |
 | Total User Stories | 21 |
+| **Completed** | **21** ✅ |
 | Must Have | 12 |
 | Should Have | 7 |
 | Could Have | 2 |
+
+**Phase 1 Status:** Complete - All 21 user stories implemented and deployed.
 
 ---
 
 ## Epics
 
-### [Epic 1: Infrastructure Foundation](./epic-1-infrastructure/)
+### [Epic 1: Infrastructure Foundation](./epic-1-infrastructure/) ✅
 
-| Story | Title | Priority | Points |
-|-------|-------|----------|--------|
-| [US-001](./epic-1-infrastructure/US-001-provision-vps.md) | Provision VPS Server | Must | 3 |
-| [US-002](./epic-1-infrastructure/US-002-install-k3s.md) | Install and Configure k3s Cluster | Must | 5 |
-| [US-003](./epic-1-infrastructure/US-003-configure-dns.md) | Configure Wildcard DNS | Must | 2 |
+| Story | Title | Priority | Points | Status |
+|-------|-------|----------|--------|--------|
+| [US-001](./epic-1-infrastructure/US-001-provision-vps.md) | Provision VPS Server | Must | 3 | ✅ Done |
+| [US-002](./epic-1-infrastructure/US-002-install-k3s.md) | Install and Configure k3s Cluster | Must | 5 | ✅ Done |
+| [US-003](./epic-1-infrastructure/US-003-configure-dns.md) | Configure Wildcard DNS | Must | 2 | ✅ Done |
 
-### [Epic 2: Ephemeral Environment Lifecycle](./epic-2-ephemeral-environments/)
+### [Epic 2: Ephemeral Environment Lifecycle](./epic-2-ephemeral-environments/) ✅
 
-| Story | Title | Priority | Points |
-|-------|-------|----------|--------|
-| [US-004](./epic-2-ephemeral-environments/US-004-create-namespace-on-pr-open.md) | Create Namespace on PR Open | Must | 5 |
-| [US-005](./epic-2-ephemeral-environments/US-005-deploy-application.md) | Deploy Application to PR Environment | Must | 8 |
-| [US-006](./epic-2-ephemeral-environments/US-006-create-preview-url.md) | Create Unique Preview URL | Must | 5 |
-| [US-007](./epic-2-ephemeral-environments/US-007-comment-pr-with-url.md) | Comment on PR with Preview URL | Should | 3 |
-| [US-008](./epic-2-ephemeral-environments/US-008-destroy-on-pr-close.md) | Destroy Environment on PR Close/Merge | Must | 5 |
+| Story | Title | Priority | Points | Status |
+|-------|-------|----------|--------|--------|
+| [US-004](./epic-2-ephemeral-environments/US-004-create-namespace-on-pr-open.md) | Create Namespace on PR Open | Must | 5 | ✅ Done |
+| [US-005](./epic-2-ephemeral-environments/US-005-deploy-application.md) | Deploy Application to PR Environment | Must | 8 | ✅ Done |
+| [US-006](./epic-2-ephemeral-environments/US-006-create-preview-url.md) | Create Unique Preview URL | Must | 5 | ✅ Done |
+| [US-007](./epic-2-ephemeral-environments/US-007-comment-pr-with-url.md) | Comment on PR with Preview URL | Should | 3 | ✅ Done |
+| [US-008](./epic-2-ephemeral-environments/US-008-destroy-on-pr-close.md) | Destroy Environment on PR Close/Merge | Must | 5 | ✅ Done |
 
-### [Epic 3: Database per PR](./epic-3-database/)
+### [Epic 3: Database per PR](./epic-3-database/) ✅
 
-| Story | Title | Priority | Points |
-|-------|-------|----------|--------|
-| [US-009](./epic-3-database/US-009-create-database-per-pr.md) | Create Isolated Database per PR | Must | 8 |
-| [US-010](./epic-3-database/US-010-database-credentials.md) | Secure Database Credentials Management | Must | 3 |
+| Story | Title | Priority | Points | Status |
+|-------|-------|----------|--------|--------|
+| [US-009](./epic-3-database/US-009-create-database-per-pr.md) | Create Isolated Database per PR | Must | 8 | ✅ Done |
+| [US-010](./epic-3-database/US-010-database-credentials.md) | Secure Database Credentials Management | Must | 3 | ✅ Done |
 
-### [Epic 4: Observability](./epic-4-observability/)
+### [Epic 4: Observability](./epic-4-observability/) ✅
 
-| Story | Title | Priority | Points |
-|-------|-------|----------|--------|
-| [US-011](./epic-4-observability/US-011-deploy-prometheus.md) | Deploy Prometheus for Metrics Collection | Must | 5 |
-| [US-012](./epic-4-observability/US-012-deploy-loki.md) | Deploy Loki for Log Aggregation | Must | 5 |
-| [US-013](./epic-4-observability/US-013-deploy-grafana.md) | Deploy Grafana Dashboards | Should | 5 |
-| [US-014](./epic-4-observability/US-014-configure-alerts.md) | Configure Basic Alerts | Could | 3 |
+| Story | Title | Priority | Points | Status |
+|-------|-------|----------|--------|--------|
+| [US-011](./epic-4-observability/US-011-deploy-prometheus.md) | Deploy Prometheus for Metrics Collection | Must | 5 | ✅ Done |
+| [US-012](./epic-4-observability/US-012-deploy-loki.md) | Deploy Loki for Log Aggregation | Must | 5 | ✅ Done |
+| [US-013](./epic-4-observability/US-013-deploy-grafana.md) | Deploy Grafana Dashboards | Should | 5 | ✅ Done |
+| [US-014](./epic-4-observability/US-014-configure-alerts.md) | Configure Basic Alerts | Could | 3 | ✅ Done |
 
-### [Epic 5: GitHub Runners](./epic-5-github-runners/)
+### [Epic 5: GitHub Runners](./epic-5-github-runners/) ✅
 
-| Story | Title | Priority | Points |
-|-------|-------|----------|--------|
-| [US-015](./epic-5-github-runners/US-015-deploy-arc.md) | Deploy Actions Runner Controller (ARC) | Should | 5 |
-| [US-016](./epic-5-github-runners/US-016-configure-runner-deployment.md) | Configure Runner Deployment | Should | 5 |
-| [US-017](./epic-5-github-runners/US-017-configure-github-access.md) | Configure GitHub Actions Access to Cluster | Must | 3 |
+| Story | Title | Priority | Points | Status |
+|-------|-------|----------|--------|--------|
+| [US-015](./epic-5-github-runners/US-015-deploy-arc.md) | Deploy Actions Runner Controller (ARC) | Should | 5 | ✅ Done |
+| [US-016](./epic-5-github-runners/US-016-configure-runner-deployment.md) | Configure Runner Deployment | Should | 5 | ✅ Done |
+| [US-017](./epic-5-github-runners/US-017-configure-github-access.md) | Configure GitHub Actions Access to Cluster | Must | 3 | ✅ Done |
 
-### [Epic 6: Resource Management & Security](./epic-6-security/)
+### [Epic 6: Resource Management & Security](./epic-6-security/) ✅
 
 | Story | Title | Priority | Points | Status |
 |-------|-------|----------|--------|--------|
 | [US-018](./epic-6-security/US-018-configure-resource-quotas.md) | Configure Resource Quotas | Should | 3 | ✅ Done |
 | [US-019](./epic-6-security/US-019-configure-network-policies.md) | Configure Network Policies | Should | 5 | ✅ Done |
 | [US-020](./epic-6-security/US-020-cleanup-job.md) | Implement Cleanup Job for Orphaned Resources | Should | 5 | ✅ Done |
-| [US-021](./epic-6-security/US-021-preserve-environment.md) | Preserve Environment Feature | Could | 5 | |
+| [US-021](./epic-6-security/US-021-preserve-environment.md) | Preserve Environment Feature | Could | 5 | ✅ Done |
 
 ---
 

--- a/docs/user-stories/epic-6-security/US-021-preserve-environment.md
+++ b/docs/user-stories/epic-6-security/US-021-preserve-environment.md
@@ -1,5 +1,7 @@
 # US-021: Preserve Environment Feature
 
+**Status:** Done
+
 ## User Story
 
 **As a** developer,
@@ -8,11 +10,11 @@
 
 ## Acceptance Criteria
 
-- [ ] Adding label `preserve=true` to PR prevents cleanup
-- [ ] Maximum preserve time: 48 hours
-- [ ] CronJob removes "preserve" label after 48 hours
-- [ ] Maximum 3 preserved environments at a time
-- [ ] Warning comment added to PR when preserve expires
+- [x] Adding label `preserve=true` to PR prevents cleanup
+- [x] Maximum preserve time: 48 hours
+- [x] CronJob removes "preserve" label after 48 hours
+- [x] Maximum 3 preserved environments at a time
+- [x] Warning comment added to PR when preserve expires
 
 ## Priority
 
@@ -31,4 +33,27 @@
 
 - Prevents accidental resource exhaustion
 - Useful for extended QA testing
-- Consider adding command to extend preserve time
+- `/preserve` command can be used to extend preservation
+
+## Implementation
+
+- **Preserve Workflow:** `.github/workflows/preserve-environment.yml`
+  - Triggered by `/preserve` PR comment
+  - Adds `preserve=true` label to namespace
+  - Adds `k8s-ee/preserve-until` annotation (48h from now)
+  - Enforces max 3 preserved environments quota
+
+- **Expiry CronJob:** `k8s/platform/preserve-expiry/`
+  - Runs hourly to check for expired preservations
+  - Posts warning comment 1 hour before expiry
+  - Removes preserve label when expired
+  - Cleanup job (US-020) handles actual deletion
+
+- **Alerts:** `k8s/platform/alerts/preserve-alerts.yaml`
+  - `PreserveExpiryJobFailed` - Job failures
+  - `PreserveExpiryJobNotRunning` - Job not running
+  - `TooManyPreservedEnvironments` - Quota exceeded
+
+- **Documentation:**
+  - `k8s/platform/preserve-expiry/README.md` - Installation and usage
+  - `docs/runbooks/preserve-environment.md` - Operational runbook

--- a/k8s/platform/alerts/preserve-alerts.yaml
+++ b/k8s/platform/alerts/preserve-alerts.yaml
@@ -1,0 +1,62 @@
+# PrometheusRule alerts for preserve feature monitoring
+# US-021: Preserve Environment Feature
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: preserve-expiry-alerts
+  namespace: observability
+  labels:
+    release: prometheus
+    app: kube-prometheus-stack
+spec:
+  groups:
+    - name: preserve-expiry.rules
+      rules:
+        # =====================================================================
+        # Preserve Expiry Job Alerts
+        # =====================================================================
+        - alert: PreserveExpiryJobFailed
+          expr: |
+            kube_job_status_failed{namespace="platform", job_name=~"preserve-expiry.*"} > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Preserve expiry job failed"
+            description: "The preserve-expiry CronJob has failed. Preserved environments may not expire correctly."
+            runbook_url: "https://github.com/genesluna/k8s-ephemeral-environments/blob/main/docs/runbooks/preserve-environment.md#preserveexpiryjobfailed"
+
+        - alert: PreserveExpiryJobNotRunning
+          expr: |
+            time() - kube_cronjob_status_last_schedule_time{namespace="platform", cronjob="preserve-expiry"} > 7200
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Preserve expiry job not running"
+            description: "The preserve-expiry CronJob has not run in over 2 hours (expected every hour)."
+            runbook_url: "https://github.com/genesluna/k8s-ephemeral-environments/blob/main/docs/runbooks/preserve-environment.md#preserveexpiryjobnotrunning"
+
+        # =====================================================================
+        # Preserve Quota Alerts
+        # =====================================================================
+        - alert: TooManyPreservedEnvironments
+          expr: |
+            count(kube_namespace_labels{label_preserve="true"}) > 3
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Too many preserved environments"
+            description: "There are {{ $value }} preserved environments (max 3). This may indicate quota enforcement issues."
+            runbook_url: "https://github.com/genesluna/k8s-ephemeral-environments/blob/main/docs/runbooks/preserve-environment.md#toomanypreservedenvironments"
+
+        - alert: PreservedEnvironmentsActive
+          expr: |
+            count(kube_namespace_labels{label_preserve="true"}) > 0
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "Preserved environments active"
+            description: "There are {{ $value }} preserved environment(s). This is informational only."

--- a/k8s/platform/preserve-expiry/README.md
+++ b/k8s/platform/preserve-expiry/README.md
@@ -1,0 +1,150 @@
+# Preserve Environment Feature
+
+This feature allows developers to preserve PR environments for extended testing
+(up to 48 hours) by commenting `/preserve` on their PR.
+
+## Overview
+
+| Setting | Value |
+|---------|-------|
+| Preserve Duration | 48 hours |
+| Max Preserved Environments | 3 |
+| Expiry Check Schedule | Every hour (at :30) |
+| Warning Before Expiry | 1 hour |
+
+## How It Works
+
+1. Developer comments `/preserve` on a PR
+2. GitHub Actions workflow adds `preserve=true` label to namespace
+3. Workflow adds `k8s-ee/preserve-until` annotation with expiry timestamp
+4. When PR is closed, cleanup job skips namespace (preserve label present)
+5. Hourly expiry job checks for expired preservations
+6. When expired, label is removed and cleanup job deletes namespace
+
+## Usage
+
+### Preserve an Environment
+
+Comment on your PR:
+
+```
+/preserve
+```
+
+You'll receive a confirmation comment with the expiry time.
+
+### Extend Preservation
+
+To extend an already-preserved environment, comment `/preserve` again.
+This resets the 48-hour timer.
+
+### Limitations
+
+- Maximum 3 preserved environments at a time (cluster-wide)
+- Maximum preservation time: 48 hours
+- Cannot preserve environments for closed PRs
+
+## Installation
+
+### Prerequisites
+
+1. Platform namespace exists (`kubectl apply -f k8s/platform/namespace.yaml`)
+2. GitHub token secret exists (`github-cleanup-token`)
+3. Cleanup job RBAC exists (`cleanup-job-sa` ServiceAccount)
+
+### Deploy the Expiry Job
+
+```bash
+kubectl apply -f k8s/platform/preserve-expiry/preserve-expiry-configmap.yaml
+kubectl apply -f k8s/platform/preserve-expiry/preserve-expiry-cronjob.yaml
+```
+
+### Deploy Alerting Rules (if Prometheus is installed)
+
+```bash
+kubectl apply -f k8s/platform/alerts/preserve-alerts.yaml
+```
+
+**Note:** If you change `MAX_PRESERVED_ENVIRONMENTS` in the workflow, you must also update
+the threshold in `k8s/platform/alerts/preserve-alerts.yaml` (TooManyPreservedEnvironments alert).
+
+## Manual Operations
+
+### Check Preserved Environments
+
+```bash
+kubectl get namespaces -l preserve=true
+```
+
+### Check Expiry Times
+
+```bash
+kubectl get namespaces -l preserve=true \
+  -o jsonpath='{range .items[*]}{.metadata.name}: {.metadata.annotations.k8s-ee/preserve-until}{"\n"}{end}'
+```
+
+### Manually Remove Preserve
+
+```bash
+kubectl label namespace <namespace> preserve-
+```
+
+### Run Expiry Job Manually
+
+```bash
+kubectl create job --from=cronjob/preserve-expiry manual-expiry -n platform
+```
+
+## Troubleshooting
+
+### Preserve Command Not Working
+
+1. Check if workflow is enabled:
+   ```bash
+   gh workflow list
+   ```
+
+2. Check workflow run status:
+   ```bash
+   gh run list --workflow=preserve-environment.yml
+   ```
+
+3. Verify namespace exists:
+   ```bash
+   kubectl get namespace <project-id>-pr-<number>
+   ```
+
+### Quota Exceeded
+
+Check current preserved environments:
+
+```bash
+kubectl get namespaces -l preserve=true --no-headers | wc -l
+```
+
+Wait for an existing preserved environment to expire or manually release one:
+
+```bash
+kubectl label namespace <namespace> preserve-
+```
+
+### Expiry Job Not Running
+
+Check CronJob status:
+
+```bash
+kubectl get cronjob preserve-expiry -n platform
+kubectl describe cronjob preserve-expiry -n platform
+```
+
+Check recent job runs:
+
+```bash
+kubectl get jobs -n platform -l app.kubernetes.io/name=preserve-expiry
+```
+
+## Related Documentation
+
+- [Cleanup Job](../cleanup-job/README.md) - Handles namespace deletion
+- [US-021 User Story](../../../docs/user-stories/epic-6-security/US-021-preserve-environment.md)
+- [Operational Runbook](../../../docs/runbooks/preserve-environment.md)

--- a/k8s/platform/preserve-expiry/preserve-expiry-configmap.yaml
+++ b/k8s/platform/preserve-expiry/preserve-expiry-configmap.yaml
@@ -1,0 +1,332 @@
+# ConfigMap containing the preserve expiry script
+# This script checks for expired preserve labels and removes them
+#
+# US-021: Preserve Environment Feature
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: preserve-expiry-script
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: preserve-expiry
+    app.kubernetes.io/component: script
+data:
+  preserve-expiry.py: |
+    #!/usr/bin/env python3
+    """
+    Preserve expiry script for PR namespaces.
+
+    This script checks namespaces with preserve=true label and:
+    - Posts warning comment 1 hour before expiry
+    - Removes preserve label when expired
+    - Posts notification comment when preserve is removed
+
+    The cleanup job (US-020) will then delete the namespace.
+
+    Environment Variables:
+        GITHUB_TOKEN: GitHub PAT with repo scope (required)
+        WARNING_HOURS: Hours before expiry to warn (default: 1)
+    """
+
+    import json
+    import logging
+    import os
+    import re
+    import subprocess
+    import sys
+    from datetime import datetime, timezone
+    from typing import Dict, List, Optional, Tuple
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError, URLError
+
+    # Configure logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    logger = logging.getLogger(__name__)
+
+    # Configuration
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+    try:
+        WARNING_HOURS = int(os.environ.get("WARNING_HOURS", "1"))
+    except ValueError:
+        logger.warning("Invalid WARNING_HOURS value, using default: 1")
+        WARNING_HOURS = 1
+    KUBECTL_TIMEOUT = 60
+
+    # Labels and annotations
+    LABEL_PRESERVE = "preserve"
+    ANNOTATION_PRESERVE_UNTIL = "k8s-ee/preserve-until"
+    ANNOTATION_REPOSITORY = "k8s-ee/repository"
+    ANNOTATION_WARNING_SENT = "k8s-ee/preserve-warning-sent"
+    LABEL_PR_NUMBER = "k8s-ee/pr-number"
+
+    # Metrics
+    metrics = {
+        "namespaces_checked": 0,
+        "namespaces_expired": 0,
+        "namespaces_warned": 0,
+        "labels_removed": 0,
+        "comments_posted": 0,
+        "errors": 0,
+    }
+
+
+    def run_kubectl(args: List[str], timeout: int = KUBECTL_TIMEOUT) -> Tuple[bool, str]:
+        """Execute kubectl command and return success status and output."""
+        try:
+            result = subprocess.run(
+                ["kubectl"] + args,
+                capture_output=True,
+                text=True,
+                timeout=timeout
+            )
+            if result.returncode == 0:
+                return True, result.stdout.strip()
+            return False, result.stderr.strip()
+        except subprocess.TimeoutExpired:
+            return False, "Command timed out"
+        except FileNotFoundError:
+            return False, "kubectl not found"
+        except Exception as e:
+            return False, str(e)
+
+
+    def get_preserved_namespaces() -> List[Dict]:
+        """Get all namespaces with preserve=true label."""
+        success, output = run_kubectl([
+            "get", "namespaces",
+            "-l", f"{LABEL_PRESERVE}=true",
+            "-o", "json"
+        ])
+
+        if not success:
+            logger.error(f"Failed to list preserved namespaces: {output}")
+            return []
+
+        try:
+            data = json.loads(output)
+            return data.get("items", [])
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse namespace JSON: {e}")
+            return []
+
+
+    def parse_namespace_metadata(namespace: Dict) -> Dict:
+        """Extract relevant metadata from namespace object."""
+        metadata = namespace.get("metadata", {})
+        labels = metadata.get("labels", {})
+        annotations = metadata.get("annotations", {})
+
+        return {
+            "name": metadata.get("name", ""),
+            "preserve_until": annotations.get(ANNOTATION_PRESERVE_UNTIL, ""),
+            "repository": annotations.get(ANNOTATION_REPOSITORY, ""),
+            "pr_number": labels.get(LABEL_PR_NUMBER, ""),
+            "warning_sent": annotations.get(ANNOTATION_WARNING_SENT, "") == "true",
+        }
+
+
+    def parse_timestamp(timestamp: str) -> Optional[datetime]:
+        """Parse ISO 8601 timestamp."""
+        if not timestamp:
+            return None
+        try:
+            if timestamp.endswith("Z"):
+                timestamp = timestamp[:-1] + "+00:00"
+            return datetime.fromisoformat(timestamp)
+        except ValueError as e:
+            logger.warning(f"Failed to parse timestamp '{timestamp}': {e}")
+            return None
+
+
+    def post_github_comment(owner: str, repo: str, pr_number: int, body: str) -> bool:
+        """Post a comment on a GitHub PR."""
+        if not GITHUB_TOKEN:
+            logger.error("GITHUB_TOKEN not set")
+            return False
+
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+        headers = {
+            "Authorization": f"Bearer {GITHUB_TOKEN}",
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "k8s-ee-preserve-expiry",
+            "Content-Type": "application/json"
+        }
+
+        try:
+            data = json.dumps({"body": body}).encode("utf-8")
+            request = Request(url, data=data, headers=headers, method="POST")
+            with urlopen(request, timeout=30) as response:
+                if response.status in (200, 201):
+                    logger.info(f"Posted comment to {owner}/{repo}#{pr_number}")
+                    return True
+            return False
+        except HTTPError as e:
+            logger.error(f"GitHub API error posting comment: {e.code}")
+            return False
+        except URLError as e:
+            logger.error(f"Network error posting comment: {e}")
+            return False
+
+
+    def remove_preserve_label(namespace: str) -> bool:
+        """Remove preserve label from namespace."""
+        success, output = run_kubectl([
+            "label", "namespace", namespace,
+            f"{LABEL_PRESERVE}-"
+        ])
+
+        if not success:
+            logger.error(f"Failed to remove preserve label from {namespace}: {output}")
+            return False
+
+        logger.info(f"Removed preserve label from {namespace}")
+        return True
+
+
+    def mark_warning_sent(namespace: str) -> bool:
+        """Mark that warning has been sent for this namespace."""
+        success, output = run_kubectl([
+            "annotate", "namespace", namespace,
+            f"{ANNOTATION_WARNING_SENT}=true",
+            "--overwrite"
+        ])
+
+        if not success:
+            logger.warning(f"Failed to mark warning sent for {namespace}: {output}")
+            return False
+
+        return True
+
+
+    def process_namespace(ns_meta: Dict) -> str:
+        """
+        Process a single preserved namespace.
+        Returns: 'expired', 'warned', 'ok', 'error'
+        """
+        name = ns_meta["name"]
+        preserve_until = parse_timestamp(ns_meta["preserve_until"])
+
+        if preserve_until is None:
+            logger.warning(f"Namespace {name} has no valid preserve-until timestamp")
+            return "error"
+
+        now = datetime.now(timezone.utc)
+        time_remaining = preserve_until - now
+        hours_remaining = time_remaining.total_seconds() / 3600
+
+        logger.info(f"Namespace {name}: {hours_remaining:.1f} hours until expiry")
+
+        # Parse repository for GitHub API
+        repository = ns_meta["repository"]
+        pr_number = ns_meta["pr_number"]
+
+        if repository and "/" in repository and pr_number:
+            owner, repo = repository.split("/", 1)
+            pr_num = int(pr_number) if pr_number.isdigit() else 0
+        else:
+            owner, repo, pr_num = None, None, 0
+
+        # Check if expired
+        if hours_remaining <= 0:
+            logger.info(f"Namespace {name} preserve has expired, removing label")
+
+            if remove_preserve_label(name):
+                metrics["labels_removed"] += 1
+
+                # Post expiry comment
+                if owner and repo and pr_num:
+                    body = "\n".join([
+                        "## :unlock: Preserve Expired",
+                        "",
+                        f"The preserve label for namespace `{name}` has expired.",
+                        "",
+                        "The environment will be cleaned up by the next cleanup job run.",
+                        "",
+                        "---",
+                        "<sub>Managed by GitHub Actions</sub>",
+                    ])
+                    if post_github_comment(owner, repo, pr_num, body):
+                        metrics["comments_posted"] += 1
+
+                return "expired"
+            return "error"
+
+        # Check if warning needed (1 hour before expiry)
+        if hours_remaining <= WARNING_HOURS and not ns_meta["warning_sent"]:
+            logger.info(f"Namespace {name} expires in {hours_remaining:.1f}h, sending warning")
+
+            if owner and repo and pr_num:
+                expiry_time = preserve_until.strftime("%Y-%m-%d %H:%M UTC")
+                body = "\n".join([
+                    "## :warning: Preserve Expiring Soon",
+                    "",
+                    f"The preserve for namespace `{name}` will expire in approximately {int(hours_remaining * 60)} minutes.",
+                    "",
+                    f"**Expires at:** {expiry_time}",
+                    "",
+                    "To extend preservation, comment `/preserve` on this PR.",
+                    "",
+                    "---",
+                    "<sub>Managed by GitHub Actions</sub>",
+                ])
+                if post_github_comment(owner, repo, pr_num, body):
+                    metrics["comments_posted"] += 1
+                    mark_warning_sent(name)
+                    return "warned"
+
+            return "ok"
+
+        return "ok"
+
+
+    def main() -> int:
+        """Main entry point. Returns exit code."""
+        logger.info("=" * 60)
+        logger.info("Starting preserve expiry check")
+        logger.info(f"Warning threshold: {WARNING_HOURS} hour(s)")
+        logger.info("=" * 60)
+
+        if not GITHUB_TOKEN:
+            logger.error("GITHUB_TOKEN environment variable is required")
+            return 1
+
+        # Get all preserved namespaces
+        namespaces = get_preserved_namespaces()
+        logger.info(f"Found {len(namespaces)} preserved namespace(s)")
+        metrics["namespaces_checked"] = len(namespaces)
+
+        for ns in namespaces:
+            ns_meta = parse_namespace_metadata(ns)
+            result = process_namespace(ns_meta)
+
+            if result == "expired":
+                metrics["namespaces_expired"] += 1
+            elif result == "warned":
+                metrics["namespaces_warned"] += 1
+            elif result == "error":
+                metrics["errors"] += 1
+
+        # Log summary
+        logger.info("=" * 60)
+        logger.info("Preserve Expiry Summary:")
+        logger.info(f"  Namespaces checked: {metrics['namespaces_checked']}")
+        logger.info(f"  Expired (labels removed): {metrics['namespaces_expired']}")
+        logger.info(f"  Warnings sent: {metrics['namespaces_warned']}")
+        logger.info(f"  Comments posted: {metrics['comments_posted']}")
+        logger.info(f"  Errors: {metrics['errors']}")
+        logger.info("=" * 60)
+
+        if metrics["errors"] > 0:
+            logger.warning("Some operations failed")
+            return 1
+
+        logger.info("Preserve expiry check completed successfully")
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())

--- a/k8s/platform/preserve-expiry/preserve-expiry-cronjob.yaml
+++ b/k8s/platform/preserve-expiry/preserve-expiry-cronjob.yaml
@@ -1,0 +1,134 @@
+# CronJob for checking and expiring preserve labels
+# Runs every hour to check for expired preservations
+#
+# US-021: Preserve Environment Feature
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: preserve-expiry
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: preserve-expiry
+    app.kubernetes.io/component: cronjob
+spec:
+  # Run every hour at minute 30
+  schedule: "30 * * * *"
+
+  # Concurrency policy: don't run if previous job is still running
+  concurrencyPolicy: Forbid
+
+  # Keep history for debugging
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+
+  # Don't start if missed by more than 1 hour
+  startingDeadlineSeconds: 3600
+
+  jobTemplate:
+    spec:
+      # Job timeout: 10 minutes max
+      activeDeadlineSeconds: 600
+
+      # Don't retry on failure - next scheduled run will handle it
+      backoffLimit: 1
+
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: preserve-expiry
+            app.kubernetes.io/component: job
+        spec:
+          # Reuse cleanup job service account (has required permissions)
+          serviceAccountName: cleanup-job-sa
+          restartPolicy: Never
+
+          # Security context
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+
+          initContainers:
+            # Install kubectl into shared volume
+            # NOTE: Using :latest because specific version tags (e.g., 1.30, 1.31)
+            # lack ARM64 images. The :latest tag includes multi-arch support.
+            # See: https://hub.docker.com/r/bitnami/kubectl/tags
+            - name: install-kubectl
+              image: bitnami/kubectl:latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - cp /opt/bitnami/kubectl/bin/kubectl /shared/kubectl
+              volumeMounts:
+                - name: shared
+                  mountPath: /shared
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
+
+          containers:
+            - name: preserve-expiry
+              # ARM64-compatible Python image
+              image: python:3.12-alpine
+              imagePullPolicy: IfNotPresent
+
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  export PATH="/shared:$PATH"
+                  python3 /scripts/preserve-expiry.py
+
+              env:
+                # GitHub token from secret (reuse cleanup job secret)
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: github-cleanup-token
+                      key: GITHUB_TOKEN
+
+                # Warning threshold (hours before expiry)
+                - name: WARNING_HOURS
+                  value: "1"
+
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: shared
+                  mountPath: /shared
+                  readOnly: true
+
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+
+          volumes:
+            - name: script
+              configMap:
+                name: preserve-expiry-script
+                defaultMode: 0555
+            - name: shared
+              emptyDir: {}
+
+          # Tolerate ARM64 nodes
+          tolerations:
+            - key: "kubernetes.io/arch"
+              operator: "Equal"
+              value: "arm64"
+              effect: "NoSchedule"


### PR DESCRIPTION
## Summary

- Implement `/preserve` PR comment command to keep environments for extended testing (48h)
- Add preserve-expiry CronJob to automatically remove expired preserve labels
- Update pr-environment workflow to respect preserve label before deletion
- Add PrometheusRule alerts for monitoring preserve feature
- Mark all 21 user stories as complete (Phase 1 done)

## Changes

### New Files
- `.github/workflows/preserve-environment.yml` - Workflow for `/preserve` command
- `k8s/platform/preserve-expiry/preserve-expiry-cronjob.yaml` - Hourly expiry check
- `k8s/platform/preserve-expiry/preserve-expiry-configmap.yaml` - Python expiry script
- `k8s/platform/alerts/preserve-alerts.yaml` - Monitoring alerts
- `k8s/platform/preserve-expiry/README.md` - Feature documentation
- `docs/runbooks/preserve-environment.md` - Operational runbook

### Modified Files
- `.github/workflows/pr-environment.yml` - Check preserve label before deletion
- `README.md` - Update project status to Phase 1 complete
- `docs/user-stories/README.md` - Mark all stories as Done

## Test plan

- [ ] Comment `/preserve` on a PR - should add preserve label
- [ ] Check namespace has `preserve=true` label and `k8s-ee/preserve-until` annotation
- [ ] Try to preserve when 3 already exist - should reject with quota error
- [ ] Close PR with preserved namespace - should NOT delete namespace
- [ ] Wait for preserve to expire - should remove label and post comment
- [ ] Verify cleanup job deletes namespace after preserve expires

Closes #21