### PR TITLE
fix(build-image): tolerate GHA cache export failures

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -294,7 +294,7 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=max,ignore-error=true
 
     - name: Set image reference output
       id: image-ref


### PR DESCRIPTION
## Problem

In `.github/actions/build-image`, the buildx cache export (`cache-to: type=gha,mode=max`) runs **after** the image has already been pushed to the registry. When a consuming repository's Actions cache is at or over GitHub's 10 GB per-repo limit, the export fails with:

```
error writing layer blob: failed to reserve cache
```

Because buildx exits non-zero on cache-export failure, the entire `Build and push` step is marked failed — even though the image was pushed successfully. This surfaces as intermittent "hang then fail" builds (the long `preparing build cache for export` step precedes the doomed reserve), and re-runs don't help because the cache is still full.

## Fix

Add `ignore-error=true` to `cache-to`, so a cache export failure becomes a warning rather than failing the build. The pushed image is unaffected; only the (best-effort) cache population is skipped when the backend can't accept it.

```diff
- cache-to: type=gha,mode=max
+ cache-to: type=gha,mode=max,ignore-error=true
```

## Notes

`ignore-error` addresses the failure mode. For repos that repeatedly saturate the 10 GB GHA cache, follow-ups worth considering are `mode=min` (smaller exports) or a registry-backed cache (`type=registry`), which sidesteps the GHA limit entirely.